### PR TITLE
Remove old useless line with dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,5 @@
  - [VoiceOver on Mac](https://tetralogical.github.io/screen-reader-HTML-support/VO-mac.html) in progress not safe to use.
  - [VoiceOver on iOS](https://tetralogical.github.io/screen-reader-HTML-support/VO-ios.html) in progress not safe to use.
  - [TalkBack on Android](https://tetralogical.github.io/screen-reader-HTML-support/TalkBack-android.html) in progress not safe to use.
-- [HTML Element test file index](https://tetralogical.github.io/AT-browser-tests/) – test files used for screen reader testing, amongst other things. safe to use
 
 As they should be, these resources are open source: Forks, [Issues](https://github.com/TetraLogical/screen-reader-HTML-support/issues) and [PR’s](https://github.com/TetraLogical/screen-reader-HTML-support/pulls) welcome!


### PR DESCRIPTION
Hello,

The link which is pointing the test page is dead. 
Maybe we could remove the line ?

https://tetralogical.github.io/AT-browser-tests/

Sorry, if I missed something on the navigation.