### PR TITLE
Change svg icons to use <symbol> and <use>

### DIFF
--- a/JAWS.html
+++ b/JAWS.html
@@ -31,6 +31,52 @@ th[scope="row"],td {vertical-align: top;}
 </style>
 </head>
 <body>
+<svg style="display:none">
+<symbol id="yes">
+    <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
+    21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
+    26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248
+    6.248-16.379
+    0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
+    0L184
+    302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
+    0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104
+    104c6.249 6.25 16.379 6.25 22.628.001z"></path>
+</symbol>
+<symbol id="no">
+    <path d="M464 32H48C21.5 32 0
+    53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
+    48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
+    12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
+    313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
+    0l-40.5-40.5c-4.8-4.8-4.8-12.6
+    0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
+    0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
+    66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8 4.8
+    12.6 0 17.4L313.3 256l67.1 66.5z"></path>
+</symbol>
+<symbol id="noneE">
+    <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48
+    48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92
+    296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0
+    12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path>
+</symbol>
+<symbol id="unknown">
+    <path d="M504 256c0
+    136.997-111.043 248-248 248S8 392.997 8 256C8 119.083
+    119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497
+    0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415
+    2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008
+    16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797
+    20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363
+    22.667-32.534 33.976C247.128 238.528 216 254.941 216
+    296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
+    12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
+    0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
+    20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
+    46-46c0-25.365-20.635-46-46-46z"></path>
+</symbol>
+</svg>
 <header class="site-head">
   <div class="wrapper"> <a href="#main" class="cta skip-link" data-cta-variant="secondary"> <span>Skip to content</span>
     <svg aria-hidden="true" role="presentation" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
@@ -69,7 +115,6 @@ th[scope="row"],td {vertical-align: top;}
 <p><strong>Editor:</strong> Steve Faulkner</p>
 <p><strong>GitHub Repo:</strong> <a href="https://github.com/TetraLogical/screen-reader-HTML-support">screen-reader-HTML-support</a> </p>
 <p>Found a bug? Please <a href="https://github.com/TetraLogical/screen-reader-HTML-support/issues">report it</a>. </p>
-</header>
 <main>
 <h2>How HTML elements are supported by screen readers</h2>
 <p> Typical support patterns of HTML elements by screen readers: </p>
@@ -99,26 +144,11 @@ th[scope="row"],td {vertical-align: top;}
 <h2>Support legend</h2>
 <ul>
   <li>
-    <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248
-6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104
-104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+    <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     means we have found this feature to be implemented
     interoperably (across multiple browsers)</li>
   <li>
-    <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-      <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48
-48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92
-296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0
-12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-    </svg>
+    <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     means the element has no expected semantics.</li>
   <li>
     <svg viewBox="0 0 512 512" width="20" aria-label="question
@@ -141,16 +171,7 @@ mark" class="unknown" role="img">
     are unsure whether this feature is supported, this may be due
     to lack of testing or lack of clarity around what 'support' of
     this feature is supposed to convey to the user.</li>
-	<li><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><path d="M464 32H48C21.5 32 0
-53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-0l-40.5-40.5c-4.8-4.8-4.8-12.6
-0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8 4.8
-12.6 0 17.4L313.3 256l67.1 66.5z"></path></svg> means we
+	<li><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg> means we
 have found that this feature is not implemented</li>
 </ul>
 <div class="table-wrapper" role="region" aria-label="Table" tabindex="0">
@@ -197,25 +218,10 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
 <td>
 <p>
 <strong>With <code>href</code>:</strong>
-<svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-<path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248
-6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104
-104c6.249 6.25 16.379 6.25 22.628.001z"></path>
+<svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
 </p>
 <p> With no <code>href</code>:
-  <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-    <path d="M400 32H48C21.5 32
-0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0
-48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12
-5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-  </svg>
+  <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
 </p>
 </td>
 <td><p> <strong>With <code>href</code>:</strong> </p>
@@ -264,28 +270,10 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       the Web/HTML/PDFs group. Next, expand the Reading group
       and use the abbreviation and acronym options</p></td>
   <td><p>By default
-      <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-        <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5
-21.5 48 48 48h352c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12
-5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-      </svg>
+      <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </p>
     <p>Via preference
-      <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-        <path d="M400 480H48c-26.51
-0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51
-0 48 21.49 48 48v352c0 26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-
-
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-      </svg>
+      <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </p></td>
   <td><p>No semantics conveyed by default</p>
     <p>Note that expansions are not announced by default and
@@ -303,33 +291,10 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
     present. </td>
   <td>No special commands</td>
   <td><p>no accessible name
-      <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-        <path d="M464 32H48C21.5 32
-0 53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0
-48-21.5 48-48V80c0-26.5-21.5-48-48-48zm-83.6
-290.5c4.8 4.8 4.8 12.6 0 17.4l-40.5 40.5c-4.8
-4.8-12.6 4.8-17.4 0L256 313.3l-66.5 67.1c-4.8
-4.8-12.6 4.8-17.4 0l-40.5-40.5c-4.8-4.8-4.8-12.6
-0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-      </svg>
+      <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     </p>
     <p>With accessible name
-      <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-        <path d="M400 480H48c-26.51
-0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51
-0 48 21.49 48 48v352c0 26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-
-
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-      </svg>
+      <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </p></td>
   <td>With accessible name <code>address</code> is announced
     as a <code>group</code> Group - accessible name,
@@ -354,17 +319,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Next Non Link Text <kbd>N</kbd></li>
       <li>Prior Non Link Text <kbd>SHIFT+N</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>Although area elements are links they are not conveyed
     as links aurally.</td>
@@ -376,18 +331,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>not supported, all <code>aria-level</code> reported as <code>h2</code><br></td>
   <td><ul>
     </ul></td>
-  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-      <path d="M464 32H48C21.5 32 0
-53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-0l-40.5-40.5c-4.8-4.8-4.8-12.6
-0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8 4.8
-12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     <br></td>
   <td>Issue filed: <a href="https://github.com/FreedomScientific/standards-support/issues/814">JAWS
     
@@ -407,17 +351,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Article List <kbd>INSERT+CTRL+O</kbd> <br>
       </li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>Included as a navigable region &lt; JAWS 2018</td>
 </tr>
@@ -434,17 +368,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Select a Region <kbd>INSERT+CTRL+R</kbd> <br>
       </li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>Included as a navigable region</td>
 </tr>
@@ -455,17 +379,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>"audio" "group+<em>accessible name</em>" announces
     controls as navigated.</td>
   <td> If the audio element has a <code>controls</code> attribute the buttons in the UI are navigable using <a href="#button-commands">button</a> commands. </td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -475,13 +389,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>Keywords</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-      <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-48 48 48h352c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     <br></td>
   <td>Refer to: <a href="https://www.tpgi.com/screen-readers-support-for-text-level-html-semantics/">Scree Readers support for text level HTML semantics</a></td>
 </tr>
@@ -494,13 +402,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
     context</a> for <a data-anolis-xref="attr-hyperlink-target" href="https://html.spec.whatwg.org/multipage/links.html#hyperlink">hyperlinks</a> and <a data-anolis-xref="attr-fs-target" href="https://html.spec.whatwg.org/multipage/form-elements.html#forms-form-submission">forms</a></td>
   <td><em>None expected</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-      <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-48 48 48h352c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     <br></td>
   <td><strong>No UI</strong></td>
 </tr>
@@ -510,13 +412,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>Text directionality isolation</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-      <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-48 48 48h352c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     <br></td>
   <td>No semantics conveyed</td>
 </tr>
@@ -526,13 +422,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>Text directionality formatting</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-      <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-48 48 48h352c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     <br></td>
   <td>No semantics conveyed</td>
 </tr>
@@ -544,17 +434,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td><ul>
       <li>List Block quotes <kbd>CTRL+INSERT+Q</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>Semantics conveyed via navigation and element name
     announcement.</td>
@@ -565,13 +445,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>Document body</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-      <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-48 48 48h352c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     <br></td>
   <td><p>No semantics conveyed</p>
     <p>Is included in focus order in most browsers.</p></td>
@@ -582,13 +456,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>Line break, e.g. in poem or postal address</td>
   <td>&nbsp;</td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-      <path d="M400 32H48C21.5 32 0
-53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     <br></td>
   <td><em>Line break</em></td>
 </tr>
@@ -602,17 +470,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Next Button <kbd>B</kbd></li>
       <li>Previous button <kbd>B</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>Semantics conveyed via navigation and element name
     announcement</td>
@@ -623,17 +481,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>Scriptable bitmap canvas</td>
   <td><em>"graphic" element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td> The canvas is 'transparent' for screen reader users.
     HTML content included in the <a href="https://www.tpgi.com/html5-canvas-sub-dom/">HTML5
@@ -646,17 +494,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>Table caption</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td> Announced when a table is navigated to. Used as table
     title in the table list (List Tables <kbd>CTRL+INSERT+T</kbd>)
@@ -668,13 +506,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>Reference to a creative work</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-      <path d="M400 32H48C21.5 32 0
-53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     <br></td>
   <td><p>No semantics conveyed or expected as <code>&lt;cite&gt;</code> has a <code>role="generic"</code></p></td>
 </tr>
@@ -684,13 +516,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>Computer code</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-      <path d="M400 32H48C21.5 32 0
-53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     <br></td>
   <td><p>No semantics conveyed or expected as <code>&lt;code&gt;</code> currently has a <code>role="generic"</code></p></td>
 </tr>
@@ -700,13 +526,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>Table column</td>
   <td><em>None expected</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-      <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-48 48 48h352c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     <br></td>
   <td>No semantics conveyed</td>
 </tr>
@@ -716,13 +536,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>Group of columns in a table</td>
   <td><em>None expected</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-      <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-48 48 48h352c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -732,13 +546,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>Machine-readable equivalent</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-      <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-48 48 48h352c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     <br></td>
   <td><p>No semantics conveyed or expected as <code>&lt;data&gt;</code> has a <code>role="generic"</code></p></td>
 </tr>
@@ -756,17 +564,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Move to Prior Combo Box <kbd>SHIFT+C </kbd></li>
       <li>List of Combo boxes <kbd>CTRL+INSERT+C</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -776,17 +574,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td> Content for corresponding <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-dt-element">dt</a> element(s) </td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td> Included as part of <code>dt</code> list item, user
     must use <kbd>arrow down</kbd> for content to be
@@ -800,17 +588,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>voice change, deletion <em>Element content</em> end
     deletion</td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg></td>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
   <td>Refer to: <a href="https://www.tpgi.com/screen-readers-support-for-text-level-html-semantics/">Scree Readers support for text level HTML semantics</a></td>
 </tr>
 <tr>
@@ -820,17 +598,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>When the details element has an accessible name it is
     announced along with group start/end.</td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg></td>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
   <td>Refer to <a href="#el-summary"><code>summary</code></a> element</td>
 </tr>
 <tr>
@@ -839,18 +607,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>Defining instance of a term</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-      <path d="M464 32H48C21.5 32 0
-53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-0l-40.5-40.5c-4.8-4.8-4.8-12.6
-0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     <br></td>
   <td>No semantics conveyed Refer to <a href="https://github.com/FreedomScientific/standards-support/issues/821">JAWS tracker Issue 821</a></td>
 </tr>
@@ -860,17 +617,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>The dialog element represents a transitory part of an application, in the form of a small window ("dialog box")</td>
   <td>dialog, accessible name if provided, accessible description if provided.</td>
   <td>When the <code>dialog</code> opens focus is moved to first focusable element. <code>dialog</code> can be closed with the <kbd>ESC</kbd> key. Upon closing focus moves back to the trigger control. While displayed focus is contained within the <code>dialog</code>.</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td><b>Note:</b> Focus is contained within the <code>dialog</code>, but the browser address bar is included within the focus order. This is a browser implemented behaviour.</td>
 </tr>
@@ -884,17 +631,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Move to Prior Division <kbd>SHIFT+Z</kbd></li>
       <li>List Divisions <kbd>CTRL+INSERT+Z</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>No semantics conveyed</td>
 </tr>
@@ -911,17 +648,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li> Next Item in a List <kbd>I</kbd></li>
       <li>Previous item in a List <kbd>SHIFT+I</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -934,17 +661,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Next Item in a List <kbd>I</kbd></li>
       <li>Previous Item in a List <kbd>SHIFT+I</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>Identified as a list item</td>
 </tr>
@@ -954,13 +671,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>Stress emphasis</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-      <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-48 48 48h352c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-    </svg></td>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
   <td>No semantics conveyed. Refer to: <a href="https://www.tpgi.com/screen-readers-support-for-text-level-html-semantics/">Scree Readers support for text level HTML semantics</a></td>
 </tr>
 <tr>
@@ -969,21 +680,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#plugins">Plugins</a></td>
   <td>&nbsp;</td>
   <td>&nbsp;</td>
-  <td><svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-      <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-256C8 119.083 119.043 8 256 8s248 111.083 248
-248zM262.655 90c-54.497 0-89.255 22.957-116.549
-63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-26.31c5.205 3.947 12.621 3.008 16.665-2.122
-17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -995,17 +692,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>No special commands, fieldset presence and accessible
     name announced when first control child is navigated to
     using virtual keys navigation keys for the child control.</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>Only when <code>fieldset</code> has an accessible name
     via <code>legend</code> or other method.</td>
@@ -1016,17 +703,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td> Caption for <a href="https://html.spec.whatwg.org/multipage/grouping-content.html#the-figure-element">figure</a></td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -1037,17 +714,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>"Figure start" <em>figcaption content, element
     content, figcaption content "Figure end"</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -1065,17 +732,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Select a Region <kbd>INSERT+CTRL+R</kbd> <br>
       </li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -1094,17 +751,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Select a Region <kbd>INSERT+CTRL+R</kbd> <br>
       </li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg></td>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
   <td>No semantics conveyed unless <code>form</code> has an accessible name, then exposed as a landmark.</td>
 </tr>
 <tr id="toc-h">
@@ -1129,17 +776,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>First Heading at Level <kbd>ALT+CTRL+INSERT+1</kbd> through <kbd>6</kbd></li>
       <li>Last Heading at Level <kbd>ALT+CTRL+INSERT+ SHIFT+1</kbd> through <kbd>6</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -1149,13 +786,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>Container for document metadata</td>
   <td><em>None expected</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-      <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-48 48 48h352c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-    </svg></td>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
   <td><strong>No UI</strong></td>
 </tr>
 <tr>
@@ -1171,17 +802,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Select a Region <kbd>INSERT+CTRL+R</kbd> <br>
       </li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -1194,17 +815,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Move to Next Separator <kbd>DASH</kbd></li>
       <li>Move to Prior Separator <kbd>SHIFT+DASH</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -1214,13 +825,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>Root element</td>
   <td><em>None expected</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-      <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-48 48 48h352c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-    </svg></td>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
   <td>&nbsp;</td>
 </tr>
 <tr id="toc-i">
@@ -1229,13 +834,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>Alternate voice</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-      <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-48 48 48h352c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-    </svg></td>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
   <td>No semantics conveyed</td>
 </tr>
 <tr>
@@ -1252,17 +851,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Next Frame <kbd>M</kbd></li>
       <li>Previous Frame <kbd>SHIFT+M </kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -1276,17 +865,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Next Graphic <kbd>G</kbd></li>
       <li>Previous Graphic <kbd>SHIFT+G</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -1306,17 +885,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Next Button <kbd>B</kbd></li>
       <li>Previous button <kbd>B</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -1336,17 +905,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Move To Next Check Box <kbd>X </kbd></li>
       <li>Move to Prior Check Box <kbd>SHIFT+X</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -1362,17 +921,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>Colour picker control</td>
   <td>&nbsp;</td>
   <td>no special commands?</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>Identified as button by JAWS but not navigable using
     button navigation keys.</td>
@@ -1389,17 +938,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>date (day/month year) picker control</td>
   <td>&nbsp;</td>
   <td>&nbsp;</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -1431,21 +970,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Move To Next Edit Box <kbd>E</kbd></li>
       <li>Move to Prior Edit Box <kbd>SHIFT+E</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-      <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-256C8 119.083 119.043 8 256 8s248 111.083 248
-248zM262.655 90c-54.497 0-89.255 22.957-116.549
-63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-26.31c5.205 3.947 12.621 3.008 16.665-2.122
-17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     <br></td>
   <td>Announced as <em>edit</em> does not announce type of edit.
   <br></td>
@@ -1471,17 +996,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Move To Next Edit Box <kbd>E </kbd></li>
       <li>Move to Prior Edit Box <kbd>SHIFT+E</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>As it's a composite control, it can be navigated to
     using either button or edit commands.</td>
@@ -1495,17 +1010,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>hidden form control</td>
   <td><em>None expected</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg></td>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
   <td><strong>No UI</strong></td>
 </tr>
 <tr>
@@ -1524,17 +1029,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Next Button <kbd>B</kbd></li>
       <li>Previous button <kbd>B</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -1570,17 +1065,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Increase value <kbd>UP ARROW</kbd></li>
       <li>Decrease value <kbd>DOWN ARROW</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td><p><strong>Note:</strong> value in edit box announced as
       changed increase/decreased using arrow keys.</p>
@@ -1607,17 +1092,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Move To Next Edit Box <kbd>E </kbd></li>
       <li>Move to Prior Edit Box <kbd>SHIFT+E</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td><strong>Note:</strong> keyboard character input
     announced as "star"</td>
@@ -1646,17 +1121,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
         minimum and maximum values of the slider.</li>
       <li><kbd>PAGE UP</kbd> and <kbd>PAGE DOWN</kbd> increment or decrement the slider by a given amount.</li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td><p><strong>Note:</strong> When slider has no accessible
       name (label) or is disabled or readonly, it is
@@ -1685,17 +1150,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Move to Prior Radio Button&nbsp; <kbd>SHIFT+A</kbd> <br>
       </li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -1715,17 +1170,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Next Button <kbd>B</kbd></li>
       <li>Previous button <kbd>B</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -1745,21 +1190,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Move To Next Edit Box <kbd>E </kbd></li>
       <li>Move to Prior Edit Box <kbd>SHIFT+E</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-      <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-256C8 119.083 119.043 8 256 8s248 111.083 248
-248zM262.655 90c-54.497 0-89.255 22.957-116.549
-63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-26.31c5.205 3.947 12.621 3.008 16.665-2.122
-17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -1777,17 +1208,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Next Button <kbd>B</kbd></li>
       <li>Previous button <kbd>B</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -1807,17 +1228,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Move To Next Edit Box <kbd>E </kbd></li>
       <li>Move to Prior Edit Box <kbd>SHIFT+E</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg></td>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
   <td>&nbsp;</td>
 </tr>
 <tr>
@@ -1836,17 +1247,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Move To Next Edit Box <kbd>E </kbd></li>
       <li>Move to Prior Edit Box <kbd>SHIFT+E</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -1862,17 +1263,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
   <td>Control for setting a specific time.</td>
   <td>&nbsp;</td>
   <td>&nbsp;</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -1892,17 +1283,7 @@ JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) 
       <li>Move To Next Edit Box <kbd>E </kbd></li>
       <li>Move to Prior Edit Box <kbd>SHIFT+E</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg></td>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
   <td>&nbsp;</td>
 </tr>
 <tr>
@@ -1935,18 +1316,7 @@ text-decoration-style: initial; text-decoration-color:
 initial;">insertion/end insertion</p>
     <em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627
-22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>Refer to: <a href="https://www.tpgi.com/screen-readers-support-for-text-level-html-semantics/">Scree Readers support for text level HTML semantics</a></td>
 </tr>
@@ -1956,18 +1326,7 @@ initial;">insertion/end insertion</p>
   <td>User input</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-      <path d="M464 32H48C21.5 32 0
-53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-0l-40.5-40.5c-4.8-4.8-4.8-12.6
-0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     <br></td>
   <td>No semantics conveyed</td>
 </tr>
@@ -1990,17 +1349,7 @@ No test
   <td>Caption for a form control</td>
   <td>&nbsp;</td>
   <td>&nbsp;</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -2010,17 +1359,7 @@ No test
   <td> Caption for <a href="https://html.spec.whatwg.org/multipage/form-elements.html#the-fieldset-element"><code>fieldset</code></a></td>
   <td>&nbsp;</td>
   <td>&nbsp;</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>Refer to <a href="#toc-f">fieldset</a> element</td>
 </tr>
@@ -2041,17 +1380,7 @@ No test
       <li> Next Item in a List <kbd>I</kbd></li>
       <li> Previous Item in a List <kbd>SHIFT+I</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -2078,17 +1407,7 @@ No test
       <li>Select a Region <kbd>INSERT+CTRL+R</kbd> <br>
       </li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -2110,18 +1429,7 @@ No test
   <td>Highlight</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-      <path d="M464 32H48C21.5 32 0
-53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-0l-40.5-40.5c-4.8-4.8-4.8-12.6
-0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     <br></td>
   <td>No semantics conveyed</td>
 </tr>
@@ -2179,21 +1487,7 @@ No test
   <td>Gauge</td>
   <td>&nbsp;</td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-      <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-256C8 119.083 119.043 8 256 8s248 111.083 248
-248zM262.655 90c-54.497 0-89.255 22.957-116.549
-63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-26.31c5.205 3.947 12.621 3.008 16.665-2.122
-17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -2210,17 +1504,7 @@ No test
       <li>Select a Region <kbd>INSERT+CTRL+R</kbd> <br>
       </li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -2245,21 +1529,7 @@ No test
       <li><strong>note:</strong> No navigation keys in JAWS
         2018 &gt;</li>
     </ul></td>
-  <td><svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-      <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-256C8 119.083 119.043 8 256 8s248 111.083 248
-248zM262.655 90c-54.497 0-89.255 22.957-116.549
-63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-26.31c5.205 3.947 12.621 3.008 16.665-2.122
-17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -2275,17 +1545,7 @@ No test
       <li>Next Item in a List <kbd>I</kbd></li>
       <li>Previous item in a List <kbd>SHIFT+I</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -2295,21 +1555,7 @@ No test
   <td>Group of options in a list box</td>
   <td>&nbsp;</td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-      <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-256C8 119.083 119.043 8 256 8s248 111.083 248
-248zM262.655 90c-54.497 0-89.255 22.957-116.549
-63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-26.31c5.205 3.947 12.621 3.008 16.665-2.122
-17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -2319,17 +1565,7 @@ No test
   <td>Option in a list box or combo box control</td>
   <td>&nbsp;</td>
   <td>&nbsp;</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -2339,21 +1575,7 @@ No test
   <td>Calculated output value</td>
   <td>&nbsp;</td>
   <td>&nbsp;</td>
-  <td><svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-      <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-256C8 119.083 119.043 8 256 8s248 111.083 248
-248zM262.655 90c-54.497 0-89.255 22.957-116.549
-63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-26.31c5.205 3.947 12.621 3.008 16.665-2.122
-17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     <br></td>
   <td>No semantics conveyed</td>
 </tr>
@@ -2367,17 +1589,7 @@ No test
       <li>Next Paragraph <kbd>P</kbd></li>
       <li>Previous Paragraph <kbd>SHIFT+P</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>No aural semantics, conveyed via navigation and
     paragraph list.</td>
@@ -2388,17 +1600,7 @@ No test
   <td> Parameter for <a href="https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element">object</a></td>
   <td><em>None expected</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg></td>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
   <td><strong>No UI</strong></td>
 </tr>
 <tr>
@@ -2407,17 +1609,7 @@ No test
   <td>&nbsp;</td>
   <td><em>None expected</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg></td>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
   <td><strong>No UI</strong></td>
 </tr>
 <tr>
@@ -2426,17 +1618,7 @@ No test
   <td>Block of preformatted text</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg></td>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
   <td>No semantics conveyed</td>
 </tr>
 <tr>
@@ -2446,17 +1628,7 @@ No test
   <td><p> <em><code>value</code> content</em>, "progress bar"
       (if using arrow keys) </p></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td><p> Progress bars are not inherently focusable. But if a
       progress bar has a <code>tabindex="0"</code>, then the
@@ -2471,21 +1643,7 @@ No test
   <td>Quotation</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-      <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-256C8 119.083 119.043 8 256 8s248 111.083 248
-248zM262.655 90c-54.497 0-89.255 22.957-116.549
-63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-26.31c5.205 3.947 12.621 3.008 16.665-2.122
-17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -2495,21 +1653,7 @@ No test
   <td>&nbsp;</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-      <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-256C8 119.083 119.043 8 256 8s248 111.083 248
-248zM262.655 90c-54.497 0-89.255 22.957-116.549
-63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-26.31c5.205 3.947 12.621 3.008 16.665-2.122
-17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     <br></td>
   <td>No semantics conveyed</td>
 </tr>
@@ -2530,21 +1674,7 @@ No test
   <td>&nbsp;</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-      <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-256C8 119.083 119.043 8 256 8s248 111.083 248
-248zM262.655 90c-54.497 0-89.255 22.957-116.549
-63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-26.31c5.205 3.947 12.621 3.008 16.665-2.122
-17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     <br></td>
   <td>No semantics conveyed</td>
 </tr>
@@ -2554,21 +1684,7 @@ No test
   <td>&nbsp;</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-      <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-256C8 119.083 119.043 8 256 8s248 111.083 248
-248zM262.655 90c-54.497 0-89.255 22.957-116.549
-63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-26.31c5.205 3.947 12.621 3.008 16.665-2.122
-17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     <br></td>
   <td>No semantics conveyed</td>
 </tr>
@@ -2578,21 +1694,7 @@ No test
   <td>&nbsp;</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-      <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-256C8 119.083 119.043 8 256 8s248 111.083 248
-248zM262.655 90c-54.497 0-89.255 22.957-116.549
-63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-26.31c5.205 3.947 12.621 3.008 16.665-2.122
-17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     <br></td>
   <td>No semantics conveyed</td>
 </tr>
@@ -2602,21 +1704,7 @@ No test
   <td>&nbsp;</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-      <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-256C8 119.083 119.043 8 256 8s248 111.083 248
-248zM262.655 90c-54.497 0-89.255 22.957-116.549
-63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-26.31c5.205 3.947 12.621 3.008 16.665-2.122
-17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -2626,21 +1714,7 @@ No test
   <td>Computer output</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-      <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-256C8 119.083 119.043 8 256 8s248 111.083 248
-248zM262.655 90c-54.497 0-89.255 22.957-116.549
-63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-26.31c5.205 3.947 12.621 3.008 16.665-2.122
-17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     <br></td>
   <td>No semantics conveyed</td>
 </tr>
@@ -2659,17 +1733,7 @@ No test
   <td>Embedded script</td>
   <td><em>None expected</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg></td>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
   <td><strong>No UI</strong></td>
 </tr>
 <tr>
@@ -2682,17 +1746,7 @@ No test
   <td>Generic document or application section</td>
   <td>&nbsp;</td>
   <td>&nbsp;</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>No semantics conveyed unless the section has an
     accessible name.</td>
@@ -2707,17 +1761,7 @@ No test
       <li>Move to Prior Combo Box <kbd>SHIFT+C </kbd></li>
       <li>List of Combo boxes <kbd>CTRL+INSERT+C</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -2727,21 +1771,7 @@ No test
   <td>Side comment</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-      <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-256C8 119.083 119.043 8 256 8s248 111.083 248
-248zM262.655 90c-54.497 0-89.255 22.957-116.549
-63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-26.31c5.205 3.947 12.621 3.008 16.665-2.122
-17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     <br></td>
   <td>No semantics conveyed</td>
 </tr>
@@ -2751,17 +1781,7 @@ No test
   <td> Media source for <a href="https://html.spec.whatwg.org/multipage/media.html#the-video-element">video</a> or <a href="https://html.spec.whatwg.org/multipage/media.html#the-audio-element">audio</a></td>
   <td><em>None expected</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg></td>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
   <td><strong>No UI</strong></td>
 </tr>
 <tr>
@@ -2770,17 +1790,7 @@ No test
   <td>Generic phrasing container</td>
   <td><em>None expected</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg></td>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
   <td>No semantics conveyed</td>
 </tr>
 <tr>
@@ -2789,21 +1799,7 @@ No test
   <td>Importance</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-      <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-256C8 119.083 119.043 8 256 8s248 111.083 248
-248zM262.655 90c-54.497 0-89.255 22.957-116.549
-63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-26.31c5.205 3.947 12.621 3.008 16.665-2.122
-17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     <br></td>
   <td>No semantics conveyed</td>
 </tr>
@@ -2822,21 +1818,7 @@ No test
   <td>Subscript</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-      <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-256C8 119.083 119.043 8 256 8s248 111.083 248
-248zM262.655 90c-54.497 0-89.255 22.957-116.549
-63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-26.31c5.205 3.947 12.621 3.008 16.665-2.122
-17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     <br></td>
   <td>No semantics conveyed</td>
 </tr>
@@ -2850,17 +1832,7 @@ No test
       <li>Next Button <kbd>B</kbd></li>
       <li>Previous button <kbd>B</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>Article <a href="https://www.scottohara.me/blog/2019/01/21/how-do-you-figure.html">How
     
@@ -2873,21 +1845,7 @@ No test
   <td>Superscript</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-      <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-256C8 119.083 119.043 8 256 8s248 111.083 248
-248zM262.655 90c-54.497 0-89.255 22.957-116.549
-63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-26.31c5.205 3.947 12.621 3.008 16.665-2.122
-17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     <br></td>
   <td>No semantics conveyed</td>
 </tr>
@@ -2897,21 +1855,7 @@ No test
   <td>&nbsp;</td>
   <td>&nbsp;</td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-      <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-256C8 119.083 119.043 8 256 8s248 111.083 248
-248zM262.655 90c-54.497 0-89.255 22.957-116.549
-63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-26.31c5.205 3.947 12.621 3.008 16.665-2.122
-17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -2929,17 +1873,7 @@ No test
         table, move to the line that reads, "Table with x
         columns and y rows," and press <kbd>F8</kbd>.</li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -2973,17 +1907,7 @@ No test
       <li>Move to and Read Cell Below <kbd>CTRL+ALT+DOWN
         ARROW</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -3006,17 +1930,7 @@ No test
       <li>Move To Next Edit Box <kbd>E</kbd></li>
       <li>Move to Prior Edit Box <kbd>SHIFT+E</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>JAWS does not announce the content of a text area when
     navigated to. If the <code>textarea</code> has text in
@@ -3031,21 +1945,7 @@ No test
   <td>Group of footer rows in a data table</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-      <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-256C8 119.083 119.043 8 256 8s248 111.083 248
-248zM262.655 90c-54.497 0-89.255 22.957-116.549
-63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-26.31c5.205 3.947 12.621 3.008 16.665-2.122
-17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     <br></td>
   <td>No semantics conveyed</td>
 </tr>
@@ -3055,17 +1955,7 @@ No test
   <td>Header cell in a data table</td>
   <td>&nbsp;</td>
   <td>&nbsp;</td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -3075,18 +1965,7 @@ No test
   <td>Group of header rows in a data table</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-      <path d="M464 32H48C21.5 32 0
-53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-0l-40.5-40.5c-4.8-4.8-4.8-12.6
-0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     <br></td>
   <td>No semantics conveyed</td>
 </tr>
@@ -3097,18 +1976,7 @@ No test
     data</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-      <path d="M464 32H48C21.5 32 0
-53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-0l-40.5-40.5c-4.8-4.8-4.8-12.6
-0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     <br></td>
   <td>No semantics conveyed</td>
 </tr>
@@ -3118,17 +1986,7 @@ No test
   <td>Document title</td>
   <td><em>Element content</em></td>
   <td>Read Window Title <kbd>INSERT+T</kbd></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>Semantics conveyed via navigation and announcement key
     stroke.</td>
@@ -3148,17 +2006,7 @@ No test
         
         UP</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -3168,21 +2016,7 @@ No test
   <td>Timed text track</td>
   <td><em>Caption display control</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-      <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-256C8 119.083 119.043 8 256 8s248 111.083 248
-248zM262.655 90c-54.497 0-89.255 22.957-116.549
-63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-26.31c5.205 3.947 12.621 3.008 16.665-2.122
-17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -3192,18 +2026,7 @@ No test
   <td>Keywords</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-      <path d="M464 32H48C21.5 32 0
-53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-0l-40.5-40.5c-4.8-4.8-4.8-12.6
-0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     <br></td>
   <td>No semantics conveyed</td>
 </tr>
@@ -3219,17 +2042,7 @@ No test
       <li>Next Item in a List <kbd>I</kbd></li>
       <li>Previous item in a List <kbd>SHIFT+I</kbd></li>
     </ul></td>
-  <td><svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-      <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48
-48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg>
+  <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -3239,18 +2052,7 @@ No test
   <td>Variable</td>
   <td><em>Element content</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-      <path d="M464 32H48C21.5 32 0
-53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-0l-40.5-40.5c-4.8-4.8-4.8-12.6
-0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     <br></td>
   <td>No semantics conveyed</td>
 </tr>
@@ -3261,21 +2063,7 @@ No test
   <td>"video" "group+<em>accessible name</em>" announces
     controls as navigated.</td>
   <td>&nbsp;</td>
-  <td><svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-      <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-256C8 119.083 119.043 8 256 8s248 111.083 248
-248zM262.655 90c-54.497 0-89.255 22.957-116.549
-63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-26.31c5.205 3.947 12.621 3.008 16.665-2.122
-17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     <br></td>
   <td>&nbsp;</td>
 </tr>
@@ -3285,21 +2073,7 @@ No test
   <td>Line breaking opportunity</td>
   <td><em>None expected</em></td>
   <td>No special commands</td>
-  <td><svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-      <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-256C8 119.083 119.043 8 256 8s248 111.083 248
-248zM262.655 90c-54.497 0-89.255 22.957-116.549
-63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-26.31c5.205 3.947 12.621 3.008 16.665-2.122
-17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path>
-    </svg>
+  <td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     <br></td>
   <td><strong>No UI</strong></td>
 </tr>

--- a/NVDA.html
+++ b/NVDA.html
@@ -27,6 +27,52 @@ body {background-color:white}
 </style>
 </head>
 <body>
+<svg style="display:none">
+<symbol id="yes">
+    <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
+    21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
+    26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248
+    6.248-16.379
+    0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
+    0L184
+    302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
+    0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104
+    104c6.249 6.25 16.379 6.25 22.628.001z"></path>
+</symbol>
+<symbol id="no">
+    <path d="M464 32H48C21.5 32 0
+    53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
+    48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
+    12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
+    313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
+    0l-40.5-40.5c-4.8-4.8-4.8-12.6
+    0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
+    0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
+    66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8 4.8
+    12.6 0 17.4L313.3 256l67.1 66.5z"></path>
+</symbol>
+<symbol id="noneE">
+    <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48
+    48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92
+    296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0
+    12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path>
+</symbol>
+<symbol id="unknown">
+    <path d="M504 256c0
+    136.997-111.043 248-248 248S8 392.997 8 256C8 119.083
+    119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497
+    0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415
+    2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008
+    16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797
+    20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363
+    22.667-32.534 33.976C247.128 238.528 216 254.941 216
+    296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
+    12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
+    0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
+    20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
+    46-46c0-25.365-20.635-46-46-46z"></path>
+</symbol>
+</svg>
 <header class="site-head">
   <div class="wrapper">
     <a href="#main" class="cta skip-link" data-cta-variant="secondary">
@@ -49,7 +95,6 @@ body {background-color:white}
 <p><strong>GitHub Repo:</strong> <a href="https://github.com/TetraLogical/screen-reader-HTML-support">screen-reader-HTML-support</a>
 </p>
 <p>Found a bug? Please <a href="https://github.com/TetraLogical/screen-reader-HTML-support/issues">report it</a>. </p>
-</header>
 <main>
 <h2>How HTML elements are supported by screen readers</h2>
 <p> Typical support patterns of HTML elements by screen readers: </p>
@@ -76,49 +121,14 @@ varies from element to element and support for a particular
 element varies between screen reader software. </p>
 <h2>Support legend</h2>
 <ul>
-<li><svg viewBox="0 0 448 512" width="20" aria-label="yes"  class="yes">
-<path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248
-6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104
-104c6.249 6.25 16.379 6.25 22.628.001z"></path> </svg>
+<li><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
 means we have found this feature to be implemented
 interoperably (across multiple browsers)</li>
-<li><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><path d="M464 32H48C21.5 32 0
-53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-0l-40.5-40.5c-4.8-4.8-4.8-12.6
-0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8 4.8
-12.6 0 17.4L313.3 256l67.1 66.5z"></path></svg> means we
+<li><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg> means we
 have found that this feature is not implemented</li>
-<li><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-<path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48
-48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92
-296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0
-12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg>
+<li><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
 means the element has no expected semantics.</li>
-<li><svg viewBox="0 0 512 512" width="20" aria-label="question
-mark" class="unknown" role="img"><path d="M504 256c0
-136.997-111.043 248-248 248S8 392.997 8 256C8 119.083
-119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497
-0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415
-2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008
-16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797
-20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path></svg> means we
+<li><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg> means we
 are unsure whether this feature is supported, this may be due
 to lack of testing or lack of clarity around what 'support' of
 this feature is supposed to convey to the user.</li>
@@ -157,16 +167,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-        <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-        21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-        26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248
-        6.248-16.379
-        0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-        0L184
-        302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-        0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104
-        104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         <p>Link role announced before link text when cursored to, after via tab. </p>
@@ -184,7 +185,7 @@ this feature is supposed to convey to the user.</li>
     <td>An anchor</td>
     <td>Announces as plain text</td>
     <td>No special commands</td>
-    <td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+    <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
     <td>Treated as regular text without any link functionality.</td>
 </tr>
 <tr>
@@ -198,16 +199,7 @@ this feature is supposed to convey to the user.</li>
         <p>No special commands</p>
         </td>
         <td>
-            <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><path d="M464 32H48C21.5 32 0
-                53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-                48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-                12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-                313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-                0l-40.5-40.5c-4.8-4.8-4.8-12.6
-                0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-                0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-                66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8 4.8
-                12.6 0 17.4L313.3 256l67.1 66.5z"></path></svg>
+            <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
         </td>
         <td>
         <p>No semantics conveyed by default</p>
@@ -227,30 +219,9 @@ this feature is supposed to convey to the user.</li>
     <td>No special commands</td>
     <td>
     <p>no accessible name
-    <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><path d="M464 32H48C21.5 32
-    0 53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0
-    48-21.5 48-48V80c0-26.5-21.5-48-48-48zm-83.6
-    290.5c4.8 4.8 4.8 12.6 0 17.4l-40.5 40.5c-4.8
-    4.8-12.6 4.8-17.4 0L256 313.3l-66.5 67.1c-4.8
-    4.8-12.6 4.8-17.4 0l-40.5-40.5c-4.8-4.8-4.8-12.6
-    0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-    0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-    66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-    4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path></svg></p>
+    <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg></p>
     <p>With accessible name
-    <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-    <path d="M400 480H48c-26.51
-    0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51
-    0 48 21.49 48 48v352c0 26.51-21.49 48-48
-    48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-    0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-    
-    
-    0L184
-    302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-    0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-    22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-    </svg></p>
+    <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></p>
     </td>
     <td>With accessible name <code>address</code> is announced
     as a <code>group</code> - accessible name grouping, followed by the content.</td>
@@ -279,17 +250,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Although area elements are links, they are not conveyed as links aurally when navigated to using the <kbd>TAB</kbd> key.</td>
 </tr>
@@ -300,17 +261,7 @@ this feature is supposed to convey to the user.</li>
     <td>Announced as "level" followed by the level number specified</td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Recognized as a hierarchical level</td>
 </tr>
@@ -323,16 +274,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><path d="M464 32H48C21.5 32 0
-            53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-            12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-            313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-            0l-40.5-40.5c-4.8-4.8-4.8-12.6
-            0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-            0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-            66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8 4.8
-            12.6 0 17.4L313.3 256l67.1 66.5z"></path></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -349,17 +291,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Recognized as a landmark region</td>
 </tr>
@@ -370,17 +302,7 @@ this feature is supposed to convey to the user.</li>
     <td>The accessible name is announced if provided. Does not announce audio.</td>
     <td> If the audio element has a <code>controls</code> attribute the buttons in the UI are navigable using <a href="#button-commands">button</a> commands.</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Buttons in the audio player are accessible.</td>
 </tr>
@@ -391,13 +313,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>Refer to: <a href="https://www.tpgi.com/screen-readers-support-for-text-level-html-semantics/">Screen Readers support for text level HTML semantics</a></td>
 </tr>
@@ -411,13 +327,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td><strong>No UI</strong></td>
 </tr>
@@ -428,13 +338,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -445,13 +349,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -467,17 +365,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Semantics conveyed via navigation and element name announcement.</td>
 </tr>
@@ -488,13 +376,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No special semantics conveyed.</td>
 </tr>
@@ -505,13 +387,7 @@ this feature is supposed to convey to the user.</li>
     <td>&nbsp;</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0
-    53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5
-    48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-    0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-    12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td><em>Line break</em></td>
 </tr>
@@ -528,17 +404,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Semantics conveyed via navigation and element name announcement</td>
 </tr>
@@ -549,17 +415,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>"graphic" element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td> 
         The canvas is 'transparent' for screen reader users. HTML content included in the <a href="https://www.tpgi.com/html5-canvas-sub-dom/">HTML5 canvas sub DOM</a>
@@ -574,17 +430,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td> Announced when a table is navigated to.</td>
 </tr>
@@ -595,13 +441,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0
-    53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5
-    48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-    0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-    12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>
     <p>No semantics conveyed or expected as <code>&lt;cite&gt;</code> has a <code>role="generic"</code></p>
@@ -614,13 +454,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0
-    53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5
-    48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-    0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-    12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>
     <p>No semantics conveyed or expected as <code>&lt;code&gt;</code> currently has a <code>role="generic"</code></p>
@@ -633,13 +467,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -650,13 +478,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -667,13 +489,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No semantics conveyed or expected as <code>&lt;data&gt;</code> has a <code>role="generic"</code></td>
 </tr>
@@ -693,17 +509,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>&nbsp;  </td>
 </tr>    
@@ -714,17 +520,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td> Included as part of <code>dt</code> list item, user must use <kbd>arrow down</kbd> for content to be announced. If user navigates via list item navigation
     (Next Item in a List <kbd>I</kbd>) only the <code>dt</code> elements will be announced.</td>
@@ -736,17 +532,7 @@ this feature is supposed to convey to the user.</li>
     <td>Announces, "Deleted" <em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Refer to: <a href="https://www.tpgi.com/screen-readers-support-for-text-level-html-semantics/">Screen Readers support for text level HTML semantics</a></td>
 </tr>
@@ -757,17 +543,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Content name</em> "button", followed by the state ("Expanded" or "Collapsed").</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>The updated state is announced when the user activates the button. Refer to <a href="#el-summary"><code>summary</code></a> element</td>
 </tr>
@@ -778,18 +554,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-            <path d="M464 32H48C21.5 32 0
-    53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-    48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-    12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-    313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-    0l-40.5-40.5c-4.8-4.8-4.8-12.6
-    0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-    0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-    66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-    4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     </td>
     <td>No semantics conveyed.</td>
 </tr>
@@ -801,17 +566,7 @@ this feature is supposed to convey to the user.</li>
     <td>When the <code>dialog</code> opens focus is moved to first focusable element. The <code>dialog</code> can be closed with the <kbd>ESC</kbd> key. 
         Upon closing focus moves back to the trigger control. While displayed focus is contained within the <code>dialog</code>.</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td><b>Note:</b> Focus is contained within the <code>dialog</code>, but the browser address bar is included within the focus order. 
         This is a browser implemented behaviour.</td>
@@ -823,17 +578,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -854,17 +599,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         Navigating using <kbd>I</kbd> and <kbd>Shift+I</kbd> in a description list moves between the <code>&lt;dt&gt;</code> elements. 
@@ -885,17 +620,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Identified as a list item</td>
 </tr>
@@ -906,13 +631,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>
         No semantics conveyed. Refer to: <a href="https://www.tpgi.com/screen-readers-support-for-text-level-html-semantics/">Screen 
@@ -935,22 +654,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-                256C8 119.083 119.043 8 256 8s248 111.083 248
-                248zM262.655 90c-54.497 0-89.255 22.957-116.549
-                63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-                26.31c5.205 3.947 12.621 3.008 16.665-2.122
-                17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-                45.698 13.148 45.698 32.958 0 14.976-12.363
-                22.667-32.534 33.976C247.128 238.528 216 254.941 216
-                296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-                12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-                0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-                20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-                46-46c0-25.365-20.635-46-46-46z">
-            </path>
-        </svg>    
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>    
     </td>
     <td>
         Firefox exposes the <code>&lt;embed&gt;</code> element as a frame. Chrome sometimes exposes the <code>&lt;embed&gt;</code> 
@@ -972,17 +676,7 @@ this feature is supposed to convey to the user.</li>
         keys navigation keys for the child control.
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Only when <code>fieldset</code> has an accessible name via <code>legend</code> or other method.</td>
 </tr>
@@ -993,17 +687,7 @@ this feature is supposed to convey to the user.</li>
     <td>Announced as, "Figure caption" <em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -1014,17 +698,7 @@ this feature is supposed to convey to the user.</li>
     <td> Announced as "Figure" if the element has an accessible name or contains a <code>&lt;figcaption&gt;</code> element.</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>"Figure" is not announced if the element does not have an accessible name or contain a <code>&lt;figcaption&gt;</code> element.</td>
 </tr>
@@ -1041,17 +715,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>The <code>&lt;footer&gt;</code> element is not exposed if used in an <code>&lt;article&gt;</code> element.</td>
 </tr>
@@ -1070,17 +734,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>No semantics conveyed unless <code>form</code> has an accessible name, then exposed as a landmark.</td>
 </tr>
@@ -1099,17 +753,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Identifies heading level and text.</td>
 </tr>
@@ -1120,13 +764,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -1143,17 +781,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>The <code>&lt;header&gt;</code> element is not exposed if used in an <code>&lt;article&gt;</code> element.</td>
 </tr>
@@ -1164,17 +792,7 @@ this feature is supposed to convey to the user.</li>
     <td>Announced as, "Separator"</td>
     <td>No special command</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Provides a clear aural indication.</td>
 </tr>
@@ -1185,13 +803,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No semantics expected.</td>
 </tr>
@@ -1202,13 +814,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No semantics conveyed.</td>
 </tr>
@@ -1229,17 +835,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -1260,17 +856,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Reads alt attribute content if present.</td>
 </tr>
@@ -1287,17 +873,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -1314,17 +890,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -1342,18 +908,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-            <path d="M464 32H48C21.5 32 0
-            53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-            12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-            313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-            0l-40.5-40.5c-4.8-4.8-4.8-12.6
-            0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-            0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-            66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8 4.8
-            12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     </td>
     <td>The colour buttons in the colour dialog do not have an accessible name in Firefox.</td>
 </tr>
@@ -1370,17 +925,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         The Chrome data picker dialog does not provide context for the dates. They are announced as numbers. Context is provided using Firefox, 
@@ -1400,21 +945,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>Treated as a regular text input.</td>
 </tr>
@@ -1431,17 +962,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -1452,17 +973,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -1479,17 +990,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -1508,17 +1009,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td><strong>Note:</strong> value in edit box announced as changed increase/decreased using arrow keys.</td>
 </tr>
@@ -1535,17 +1026,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td><strong>Note:</strong> keyboard character input announced as "star".</td>
 </tr>
@@ -1562,17 +1043,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         <p>
@@ -1598,17 +1069,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -1625,17 +1086,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -1656,21 +1107,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>Treated as a regular text input.</td>
 </tr>
@@ -1687,17 +1124,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -1714,17 +1141,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-            </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -1745,17 +1162,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -1779,17 +1186,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Navigable using NVDA button keystrokes in Chrome and navigable using NVDA button keystrokes in Firefox</td>
 </tr>
@@ -1806,17 +1203,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -1827,18 +1214,7 @@ this feature is supposed to convey to the user.</li>
     <td>"Inserted" <em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627
-            22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         Refer to: <a href="https://www.tpgi.com/screen-readers-support-for-text-level-html-semantics/">Screen Readers support 
@@ -1852,18 +1228,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-            <path d="M464 32H48C21.5 32 0
-            53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-            12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-            313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-            0l-40.5-40.5c-4.8-4.8-4.8-12.6
-            0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-            0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-            66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-            4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -1874,17 +1239,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Label content</em> announced when the corresponding form control has focus</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -1897,17 +1252,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Legend content</em> is announced as the group label for a group of related controls when one of the controls is first focused in the group.</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Serves as the group label for a group of form controls. Refer to the <a href="#toc-f">fieldset</a> element</td>
 </tr>
@@ -1928,17 +1273,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -1964,17 +1299,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -1985,12 +1310,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 
-            48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 
-            296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -2001,17 +1321,7 @@ this feature is supposed to convey to the user.</li>
     <td>"Highlighted" <em>Element content</em> "out of highlighted"</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -2022,12 +1332,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 
-            48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 
-            296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -2038,21 +1343,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Accessible name</em> "progress bar" followed by the value</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>
         <ul>
@@ -2080,17 +1371,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -2101,12 +1382,7 @@ this feature is supposed to convey to the user.</li>
     <td>Content of <code>&lt;noscript&gt;</code> element read if JavaScript is not available/enabled</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 
-            48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 
-            296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>Ignored when JavaScript is enabled.</td>
 </tr>
@@ -2122,21 +1398,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>Support varies depending on object type.</td>
 </tr>
@@ -2154,17 +1416,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Announces the numerical or alphabetical value for each list item.</td>
 </tr>
@@ -2175,17 +1427,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Label content</em> "grouping"</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         The list needs to be expanded in order for the grouping information to be announced. Use <kbd>ALT</kbd> followed 
@@ -2199,17 +1441,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Option content</em> x of y; where x = position in list, y = number of items in the list</td>
     <td>Navigable using <kbd>UP</kbd>/<kbd>DOWN</kbd> arrow keys</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Use <kbd>ALT</kbd> followed by <kbd>DOWN ARROW</kbd> key to expand the list.</td>
 </tr>
@@ -2220,21 +1452,7 @@ this feature is supposed to convey to the user.</li>
     <td>Reads output value</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2250,17 +1468,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>No aural semantics.</td>
 </tr>
@@ -2271,12 +1479,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 
-            48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 
-            296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -2287,12 +1490,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 
-            48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 
-            296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -2303,17 +1501,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2328,17 +1516,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         Progress bars are not inherently focusable. But if a progress bar has <code>tabindex="0"</code>, then the accessible 
@@ -2352,21 +1530,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -2377,20 +1541,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img"><path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2401,21 +1552,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2426,21 +1563,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2451,21 +1574,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2476,21 +1585,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -2501,17 +1596,7 @@ this feature is supposed to convey to the user.</li>
     <td>"Deleted" <em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -2522,21 +1607,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2547,12 +1618,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 
-            48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 
-            296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -2576,17 +1642,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-            </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>No semantics conveyed unless the section has an accessible name.</td>
 </tr>
@@ -2603,17 +1659,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Provides list of options, recognizes <code>optgroup</code>.</td>
 </tr>
@@ -2624,21 +1670,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-                256C8 119.083 119.043 8 256 8s248 111.083 248
-                248zM262.655 90c-54.497 0-89.255 22.957-116.549
-                63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-                26.31c5.205 3.947 12.621 3.008 16.665-2.122
-                17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-                45.698 13.148 45.698 32.958 0 14.976-12.363
-                22.667-32.534 33.976C247.128 238.528 216 254.941 216
-                296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-                12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-                0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-                20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-                46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2652,17 +1684,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -2673,11 +1695,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 
-            48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 
-            5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2688,21 +1706,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2713,11 +1717,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 
-            48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 
-            5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -2728,21 +1728,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2761,17 +1747,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-        <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-        21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-        26.51-21.49 48-48
-        48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-        0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-        0L184
-        302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-        0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-        22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Serves as a trigger for expanding/collapsing <code>&lt;details&gt;</code> section.</td>
 </tr>
@@ -2782,21 +1758,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2813,21 +1775,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>The <code>&lt;svg&gt;</code> element is ignored in Firefox, unless it has <code>role="img"</code> and labelled.</td>
 </tr>
@@ -2849,17 +1797,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -2870,11 +1808,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 
-            48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 
-            5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2892,17 +1826,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Announces corresponding header if programmatically associated.</td>
 </tr>
@@ -2913,11 +1837,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 
-            48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 
-            5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -2934,17 +1854,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -2958,21 +1868,7 @@ this feature is supposed to convey to the user.</li>
     <td>&nbsp;</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2983,17 +1879,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special command. Reachable using standard table cell reading keystrokes.</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -3004,18 +1890,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-            <path d="M464 32H48C21.5 32 0
-            53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-            12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-            313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-            0l-40.5-40.5c-4.8-4.8-4.8-12.6
-            0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-            0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-            66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-            4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -3026,18 +1901,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-            <path d="M464 32H48C21.5 32 0
-            53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-            12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-            313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-            0l-40.5-40.5c-4.8-4.8-4.8-12.6
-            0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-            0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-            66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-            4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -3048,17 +1912,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>Read Window Title <kbd>INSERT+T</kbd></td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Semantics conveyed via navigation and announcement key stroke.</td>
 </tr>
@@ -3069,17 +1923,7 @@ this feature is supposed to convey to the user.</li>
     <td>&nbsp;</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -3090,21 +1934,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Caption display control</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -3115,18 +1945,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-            <path d="M464 32H48C21.5 32 0
-            53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-            12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-            313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-            0l-40.5-40.5c-4.8-4.8-4.8-12.6
-            0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-            0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-            66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-            4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -3142,17 +1961,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -3163,18 +1972,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-            <path d="M464 32H48C21.5 32 0
-                53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-                48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-                12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-                313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-                0l-40.5-40.5c-4.8-4.8-4.8-12.6
-                0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-                0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-                66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-                4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -3185,21 +1983,7 @@ this feature is supposed to convey to the user.</li>
     <td>Announces individual controls</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -3210,12 +1994,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 
-            48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 
-            296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 
-            5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>

--- a/TalkBack-android.html
+++ b/TalkBack-android.html
@@ -6,6 +6,52 @@
 <style> svg { fill: green; } svg.no { fill: red; } svg.unknown { fill: red; } </style>
 </head>
 <body>
+<svg style="display:none">
+<symbol id="yes">
+    <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
+    21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
+    26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248
+    6.248-16.379
+    0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
+    0L184
+    302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
+    0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104
+    104c6.249 6.25 16.379 6.25 22.628.001z"></path>
+</symbol>
+<symbol id="no">
+    <path d="M464 32H48C21.5 32 0
+    53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
+    48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
+    12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
+    313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
+    0l-40.5-40.5c-4.8-4.8-4.8-12.6
+    0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
+    0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
+    66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8 4.8
+    12.6 0 17.4L313.3 256l67.1 66.5z"></path>
+</symbol>
+<symbol id="noneE">
+    <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48
+    48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92
+    296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0
+    12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path>
+</symbol>
+<symbol id="unknown">
+    <path d="M504 256c0
+    136.997-111.043 248-248 248S8 392.997 8 256C8 119.083
+    119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497
+    0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415
+    2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008
+    16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797
+    20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363
+    22.667-32.534 33.976C247.128 238.528 216 254.941 216
+    296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
+    12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
+    0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
+    20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
+    46-46c0-25.365-20.635-46-46-46z"></path>
+</symbol>
+</svg>
 <header> <img src="assets/images/HTML5_Logo.png" alt="HTML5 logo" id="logo">
 <h1>TalkBack-Android HTML Support</h1>
 <p> A Work <em>in progress</em>: Last updated 02 October 2024. </p>
@@ -13,7 +59,6 @@
 <p><strong>Github Repo:</strong> <a href="https://github.com/TetraLogical/screen-reader-HTML-support">screen-reader-HTML-support</a>
 </p>
 <p>Found a bug? Please <a href="https://github.com/TetraLogical/screen-reader-HTML-support/issues">report it</a>. </p>
-</header>
 <main>
 <h1><svg viewBox="0 0 576 512" width="100" role="img" aria-label="Warning" class="unknown">
 <path d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z" />
@@ -47,49 +92,14 @@ varies from element to element and support for a particular
 element varies between screen reader software. </p>
 <h2>Support legend</h2>
 <ul>
-<li><svg viewBox="0 0 448 512" width="20" aria-label="yes">
-<path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248
-6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104
-104c6.249 6.25 16.379 6.25 22.628.001z"></path> </svg>
+<li><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
 means we have found this feature to be implemented
 interoperably (across multiple browsers)</li>
-<li><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><path d="M464 32H48C21.5 32 0
-53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-0l-40.5-40.5c-4.8-4.8-4.8-12.6
-0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8 4.8
-12.6 0 17.4L313.3 256l67.1 66.5z"></path></svg> means we
+<li><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg> means we
 have found that this feature is not implemented</li>
-<li><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected">
-<path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48
-48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92
-296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0
-12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg>
+<li><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
 means the element has no expected semantics.</li>
-<li><svg viewBox="0 0 512 512" width="20" aria-label="question
-mark" class="unknown" role="img"><path d="M504 256c0
-136.997-111.043 248-248 248S8 392.997 8 256C8 119.083
-119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497
-0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415
-2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008
-16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797
-20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path></svg> means we
+<li><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg> means we
 are unsure whether this feature is supported, this may be due
 to lack of testing or lack of clarity around what 'support' of
 this feature is supposed to convey to the user.</li>
@@ -116,7 +126,7 @@ this feature is supposed to convey to the user.</li>
 <td>Link with an <code>href</code></td>
 <td>Announces "link" + link text</td>
 <td>Swipe left/right, double-tap to activate</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognizes visited/unvisited state of links.</td>
 </tr>
 <tr>
@@ -125,7 +135,7 @@ this feature is supposed to convey to the user.</li>
 <td>Abbreviated term</td>
 <td>Reads abbreviation and title attribute</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Expands abbreviation if <code>title</code> is present.</td>
 </tr>
 <tr>
@@ -134,7 +144,7 @@ this feature is supposed to convey to the user.</li>
 <td>Contact information</td>
 <td>Reads text as normal</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>Treated as regular text; no special emphasis.</td>
 </tr>
 <tr>
@@ -143,7 +153,7 @@ this feature is supposed to convey to the user.</li>
 <td>Clickable area within an image map</td>
 <td>Announces "link" + <code>alt</code> text</td>
 <td>Swipe left/right to navigate, double-tap</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognizes <code>alt</code> text for accessibility.</td>
 </tr>
 <tr>
@@ -152,7 +162,7 @@ this feature is supposed to convey to the user.</li>
 <td>Self-contained composition</td>
 <td>Announces "article"</td>
 <td>Swipe left/right, or use local context menu</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognized as a landmark.</td>
 </tr>
 <tr>
@@ -161,7 +171,7 @@ this feature is supposed to convey to the user.</li>
 <td>Tangentially related content</td>
 <td>Announces "complementary"</td>
 <td>Swipe left/right, or use local context menu</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognized as a complementary region.</td>
 </tr>
 <tr>
@@ -170,7 +180,7 @@ this feature is supposed to convey to the user.</li>
 <td>Audio content with controls</td>
 <td>Announces "audio" or "play button"</td>
 <td>Double-tap to play/pause</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Accessible buttons available; reads controls.</td>
 </tr>
 <tr>
@@ -179,7 +189,7 @@ this feature is supposed to convey to the user.</li>
 <td>Important or emphasized text</td>
 <td>Reads content as normal text</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>No specific emphasis conveyed.</td>
 </tr>
 <tr>
@@ -188,7 +198,7 @@ this feature is supposed to convey to the user.</li>
 <td>Base URL for relative links</td>
 <td>No aural feedback</td>
 <td>Not interactive</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>Ignored by TalkBack; used for browser handling.</td>
 </tr>
 <tr>
@@ -197,7 +207,7 @@ this feature is supposed to convey to the user.</li>
 <td>Isolates a span of text</td>
 <td>Reads content as normal text</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>No semantic effect conveyed by TalkBack.</td>
 </tr>
 <tr>
@@ -206,7 +216,7 @@ this feature is supposed to convey to the user.</li>
 <td>Overrides the current text direction</td>
 <td>Reads content as normal text</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>No special aural feedback.</td>
 </tr>
 <tr>
@@ -215,7 +225,7 @@ this feature is supposed to convey to the user.</li>
 <td>Quoted block content</td>
 <td>Announces "blockquote"</td>
 <td>Swipe left/right to navigate</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognizes the blockquote start and end.</td>
 </tr>
 <tr>
@@ -224,7 +234,7 @@ this feature is supposed to convey to the user.</li>
 <td>Main content of the page</td>
 <td>Reads content</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>No unique aural feedback; treated as the main document.</td>
 </tr>
 <tr>
@@ -233,7 +243,7 @@ this feature is supposed to convey to the user.</li>
 <td>Line break within text</td>
 <td>Announces "line break"</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Treated as a natural pause or break in reading.</td>
 </tr>
 <tr>
@@ -242,7 +252,7 @@ this feature is supposed to convey to the user.</li>
 <td>Clickable button control</td>
 <td>Announces "button" + label</td>
 <td>Double-tap to activate</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognizes state (pressed/unpressed) and label.</td>
 </tr>
 <tr>
@@ -251,7 +261,7 @@ this feature is supposed to convey to the user.</li>
 <td>Scriptable bitmap canvas</td>
 <td>Announces "graphic" if <code>aria-label</code> provided</td>
 <td>Swipe left/right to navigate</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>Accessible fallback content read if provided.</td>
 </tr>
 <tr>
@@ -260,7 +270,7 @@ this feature is supposed to convey to the user.</li>
 <td>Title for a table</td>
 <td>Announces as part of the table</td>
 <td>Swipe left/right to navigate table content</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognized when navigating within a table.</td>
 </tr>
 <tr>
@@ -269,7 +279,7 @@ this feature is supposed to convey to the user.</li>
 <td>Reference to a creative work</td>
 <td>Reads content as normal text</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>No specific emphasis given.</td>
 </tr>
 <tr>
@@ -278,7 +288,7 @@ this feature is supposed to convey to the user.</li>
 <td>Inline code or programming syntax</td>
 <td>Reads content as normal text</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>No unique inflection for code snippets.</td>
 </tr>
 <tr>
@@ -287,7 +297,7 @@ this feature is supposed to convey to the user.</li>
 <td>Defines column properties</td>
 <td>No aural indication</td>
 <td>Not directly interactive</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>Structure conveyed through table headers.</td>
 </tr>
 <tr>
@@ -296,7 +306,7 @@ this feature is supposed to convey to the user.</li>
 <td>Groups multiple columns in a table</td>
 <td>No aural indication</td>
 <td>Not directly interactive</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>Contributes to table structure but not directly read.</td>
 </tr>
 <tr>
@@ -305,7 +315,7 @@ this feature is supposed to convey to the user.</li>
 <td>Data and its human-readable equivalent</td>
 <td>Reads element content</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>Treated as normal text.</td>
 </tr>
 <tr>
@@ -314,7 +324,7 @@ this feature is supposed to convey to the user.</li>
 <td>Provides options for an input field</td>
 <td>Announces "combo box"</td>
 <td>Double-tap to select</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Offers accessible suggestions when typing.</td>
 </tr>
 <tr>
@@ -323,7 +333,7 @@ this feature is supposed to convey to the user.</li>
 <td>Content of a term's description</td>
 <td>Reads element content</td>
 <td>Swipe left/right to navigate</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Properly linked to <code>dt</code>.</td>
 </tr>
 <tr>
@@ -332,7 +342,7 @@ this feature is supposed to convey to the user.</li>
 <td>Marked as deleted</td>
 <td>Announces "deleted" before reading content</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Uses distinct tone for deleted content.</td>
 </tr>
 <tr>
@@ -341,7 +351,7 @@ this feature is supposed to convey to the user.</li>
 <td>Expandable/collapsible content</td>
 <td>Announces "expandable" or "collapsed"</td>
 <td>Double-tap to expand/collapse</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognizes the expanded/collapsed state.</td>
 </tr>
 <tr>
@@ -350,7 +360,7 @@ this feature is supposed to convey to the user.</li>
 <td>Indicates a defining instance of a term</td>
 <td>Reads element content</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>No additional semantics conveyed by TalkBack.</td>
 </tr>
 <tr>
@@ -359,7 +369,7 @@ this feature is supposed to convey to the user.</li>
 <td>Modal dialog</td>
 <td>Announces "dialog"</td>
 <td>Focus moves to dialog on open</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognizes and traps focus within dialog.</td>
 </tr>
 <tr>
@@ -368,7 +378,7 @@ this feature is supposed to convey to the user.</li>
 <td>Generic block container</td>
 <td>Reads element content</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>Treated according to ARIA roles/attributes.</td>
 </tr>
 <tr>
@@ -377,7 +387,7 @@ this feature is supposed to convey to the user.</li>
 <td>List of term-definition pairs</td>
 <td>Announces "list with X items"</td>
 <td>Swipe left/right to navigate</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognizes the list structure.</td>
 </tr>
 <tr>
@@ -386,7 +396,7 @@ this feature is supposed to convey to the user.</li>
 <td>Term in a definition list</td>
 <td>Reads element content</td>
 <td>Part of list navigation</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Associated with following <code>dd</code>.</td>
 </tr>
 <tr>
@@ -395,7 +405,7 @@ this feature is supposed to convey to the user.</li>
 <td>Emphasized text</td>
 <td>Reads with slight emphasis</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Uses intonation to convey emphasis.</td>
 </tr>
 <tr>
@@ -404,7 +414,7 @@ this feature is supposed to convey to the user.</li>
 <td>Embeds external resources</td>
 <td>Announces "embedded object"</td>
 <td>Swipe left/right to navigate</td>
-<td><svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img"><path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"></path></svg></td>
+<td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg></td>
 <td>Behavior depends on the type of embedded content.</td>
 </tr>
 <tr>
@@ -413,7 +423,7 @@ this feature is supposed to convey to the user.</li>
 <td>Groups related form controls</td>
 <td>Announces "group" and reads legend</td>
 <td>Swipe left/right to navigate controls</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognizes fieldset and legend association.</td>
 </tr>
 <tr>
@@ -422,7 +432,7 @@ this feature is supposed to convey to the user.</li>
 <td>Caption for a figure element</td>
 <td>Reads caption text</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognized as part of the figure.</td>
 </tr>
 <tr>
@@ -431,7 +441,7 @@ this feature is supposed to convey to the user.</li>
 <td>Self-contained content</td>
 <td>Announces "figure"</td>
 <td>Swipe left/right to navigate</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Properly treated as a grouped item.</td>
 </tr>
 <tr>
@@ -440,7 +450,7 @@ this feature is supposed to convey to the user.</li>
 <td>Page or section footer</td>
 <td>Announces "footer"</td>
 <td>Rotor to landmarks or swipe left/right</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognized as a landmark region.</td>
 </tr>
 <tr>
@@ -449,7 +459,7 @@ this feature is supposed to convey to the user.</li>
 <td>Collects user input</td>
 <td>Announces "form"</td>
 <td>Swipe left/right to navigate controls</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognizes form controls and fieldsets.</td>
 </tr>
 <tr>
@@ -458,7 +468,7 @@ this feature is supposed to convey to the user.</li>
 <td>Headings with levels 1 to 6</td>
 <td>Announces "heading level X"</td>
 <td>Rotor to headings, swipe to navigate</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Properly identifies heading level and content.</td>
 </tr>
 <tr>
@@ -467,7 +477,7 @@ this feature is supposed to convey to the user.</li>
 <td>Header section</td>
 <td>Announces "header"</td>
 <td>Rotor to landmarks</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Identified as a landmark region.</td>
 </tr>
 <tr>
@@ -476,7 +486,7 @@ this feature is supposed to convey to the user.</li>
 <td>Horizontal rule or separator</td>
 <td>Announces "separator"</td>
 <td>Swipe left/right to navigate</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Treated as a separator line.</td>
 </tr>
 <tr>
@@ -485,7 +495,7 @@ this feature is supposed to convey to the user.</li>
 <td>Main HTML element</td>
 <td>No aural indication</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>Not directly read; root of the document.</td>
 </tr>
 <tr>
@@ -494,7 +504,7 @@ this feature is supposed to convey to the user.</li>
 <td>Nested browsing context</td>
 <td>Announces "frame"</td>
 <td>Swipe left/right to navigate</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognizes the frame's title if available.</td>
 </tr>
 <tr>
@@ -503,7 +513,7 @@ this feature is supposed to convey to the user.</li>
 <td>Embedded image</td>
 <td>Announces "image" + <code>alt</code> text</td>
 <td>Double-tap to activate or swipe to navigate</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Reads <code>alt</code> or "image" if missing.</td>
 </tr>
 <tr>
@@ -512,7 +522,7 @@ this feature is supposed to convey to the user.</li>
 <td>Clickable button</td>
 <td>Announces "button" + label</td>
 <td>Double-tap to activate</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognizes the label of the button.</td>
 </tr>
 <tr>
@@ -521,7 +531,7 @@ this feature is supposed to convey to the user.</li>
 <td>Check/uncheck control</td>
 <td>Announces "checkbox, checked/unchecked"</td>
 <td>Double-tap to toggle state</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Identifies the label and checked/unchecked state.</td>
 </tr>
 <tr>
@@ -530,7 +540,7 @@ this feature is supposed to convey to the user.</li>
 <td>Color selection control</td>
 <td>Announces "color picker"</td>
 <td>Double-tap to open the color picker</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Allows selecting colors from the palette.</td>
 </tr>
 <tr>
@@ -539,7 +549,7 @@ this feature is supposed to convey to the user.</li>
 <td>Date selection control</td>
 <td>Announces "date picker"</td>
 <td>Double-tap to open and set values</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Provides a date-specific input interface.</td>
 </tr>
 <tr>
@@ -548,7 +558,7 @@ this feature is supposed to convey to the user.</li>
 <td>Local date and time picker</td>
 <td>Announces "date and time picker"</td>
 <td>Double-tap to open, swipe to adjust values</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Combines date and time selection.</td>
 </tr>
 <tr>
@@ -557,7 +567,7 @@ this feature is supposed to convey to the user.</li>
 <td>Email address entry</td>
 <td>Announces "email field"</td>
 <td>Text entry interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Provides an email-specific keyboard.</td>
 </tr>
 <tr>
@@ -566,7 +576,7 @@ this feature is supposed to convey to the user.</li>
 <td>File selection/upload control</td>
 <td>Announces "file upload"</td>
 <td>Double-tap to choose file</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Allows file browsing and selection.</td>
 </tr>
 <tr>
@@ -575,7 +585,7 @@ this feature is supposed to convey to the user.</li>
 <td>Non-visible input</td>
 <td>No aural feedback</td>
 <td>Not interactive</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>Used for form data; ignored by TalkBack.</td>
 </tr>
 <tr>
@@ -584,7 +594,7 @@ this feature is supposed to convey to the user.</li>
 <td>Submit button with an image</td>
 <td>Announces "image button" + <code>alt</code> text</td>
 <td>Double-tap to activate</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Acts as a regular button but with an image.</td>
 </tr>
 <tr>
@@ -593,7 +603,7 @@ this feature is supposed to convey to the user.</li>
 <td>Month/year input</td>
 <td>Announces "month picker"</td>
 <td>Double-tap to adjust values</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Provides a month/year selection interface.</td>
 </tr>
 <tr>
@@ -602,7 +612,7 @@ this feature is supposed to convey to the user.</li>
 <td>Numeric entry</td>
 <td>Announces "number field"</td>
 <td>Double-tap to enter/edit</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Provides a numeric keyboard.</td>
 </tr>
 <tr>
@@ -611,7 +621,7 @@ this feature is supposed to convey to the user.</li>
 <td>Secure text entry</td>
 <td>Announces "password field"</td>
 <td>Text entry interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Input is masked as entered.</td>
 </tr>
 <tr>
@@ -620,7 +630,7 @@ this feature is supposed to convey to the user.</li>
 <td>Radio button option</td>
 <td>Announces "radio button, checked/unchecked"</td>
 <td>Double-tap to select</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognizes the radio button's group.</td>
 </tr>
 <tr>
@@ -629,7 +639,7 @@ this feature is supposed to convey to the user.</li>
 <td>Range input using a slider</td>
 <td>Announces "slider" + current value</td>
 <td>Swipe left/right to adjust</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Allows setting a value within a defined range.</td>
 </tr>
 <tr>
@@ -638,7 +648,7 @@ this feature is supposed to convey to the user.</li>
 <td>Resets form fields</td>
 <td>Announces "reset button"</td>
 <td>Double-tap to activate</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Resets all form inputs to default values.</td>
 </tr>
 <tr>
@@ -647,7 +657,7 @@ this feature is supposed to convey to the user.</li>
 <td>Search query entry</td>
 <td>Announces "search field"</td>
 <td>Text entry interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Provides a search-specific keyboard.</td>
 </tr>
 <tr>
@@ -656,7 +666,7 @@ this feature is supposed to convey to the user.</li>
 <td>Form submission button</td>
 <td>Announces "submit button"</td>
 <td>Double-tap to activate</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Submits form data to the server.</td>
 </tr>
 <tr>
@@ -665,7 +675,7 @@ this feature is supposed to convey to the user.</li>
 <td>Telephone number entry</td>
 <td>Announces "phone number field"</td>
 <td>Text entry interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Provides a telephone-specific keypad.</td>
 </tr>
 <tr>
@@ -674,7 +684,7 @@ this feature is supposed to convey to the user.</li>
 <td>Single-line text entry</td>
 <td>Announces "text field"</td>
 <td>Text entry interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Standard text input field.</td>
 </tr>
 <tr>
@@ -683,7 +693,7 @@ this feature is supposed to convey to the user.</li>
 <td>Time picker</td>
 <td>Announces "time picker"</td>
 <td>Double-tap to adjust</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Allows selecting hours and minutes.</td>
 </tr>
 <tr>
@@ -692,7 +702,7 @@ this feature is supposed to convey to the user.</li>
 <td>URL entry field</td>
 <td>Announces "URL field"</td>
 <td>Text entry interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Provides a URL-specific keyboard.</td>
 </tr>
 <tr>
@@ -701,7 +711,7 @@ this feature is supposed to convey to the user.</li>
 <td>Week number input</td>
 <td>Announces "week picker"</td>
 <td>Double-tap to adjust values</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Allows selecting a week within a year.</td>
 </tr>
 <tr>
@@ -710,7 +720,7 @@ this feature is supposed to convey to the user.</li>
 <td>Recently added text</td>
 <td>Announces "insertion"</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Uses distinct tone for inserted content.</td>
 </tr>
 <tr>
@@ -719,7 +729,7 @@ this feature is supposed to convey to the user.</li>
 <td>User keyboard input representation</td>
 <td>Reads element content</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>No unique aural treatment.</td>
 </tr>
 <tr>
@@ -728,7 +738,7 @@ this feature is supposed to convey to the user.</li>
 <td>Descriptive label for input</td>
 <td>Announces label when focusing on input</td>
 <td>Swipe to focus on associated input</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Provides context for form controls.</td>
 </tr>
 <tr>
@@ -737,7 +747,7 @@ this feature is supposed to convey to the user.</li>
 <td>Caption for a fieldset</td>
 <td>Announces as part of fieldset</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Provides context to grouped form controls.</td>
 </tr>
 <tr>
@@ -746,7 +756,7 @@ this feature is supposed to convey to the user.</li>
 <td>Item in an ordered/unordered list</td>
 <td>Announces "list item" + position</td>
 <td>Swipe to navigate</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognizes item count and position.</td>
 </tr>
 <tr>
@@ -755,7 +765,7 @@ this feature is supposed to convey to the user.</li>
 <td>Link to external resources</td>
 <td>No aural feedback</td>
 <td>Not interactive</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>Generally ignored by TalkBack.</td>
 </tr>
 <tr>
@@ -764,7 +774,7 @@ this feature is supposed to convey to the user.</li>
 <td>Main content area</td>
 <td>Announces "main"</td>
 <td>Rotor to 'landmarks' or swipe to navigate</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognized as a landmark region.</td>
 </tr>
 <tr>
@@ -773,7 +783,7 @@ this feature is supposed to convey to the user.</li>
 <td>Collection of areas within an image</td>
 <td>No direct aural indication</td>
 <td>Interaction via associated <code>&lt;area&gt;</code> elements</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognizes linked areas in the map.</td>
 </tr>
 <tr>
@@ -782,7 +792,7 @@ this feature is supposed to convey to the user.</li>
 <td>Highlighted or relevant text</td>
 <td>Reads content as normal text</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>No unique emphasis conveyed.</td>
 </tr>
 <tr>
@@ -791,7 +801,7 @@ this feature is supposed to convey to the user.</li>
 <td>Metadata about the HTML document</td>
 <td>No aural feedback</td>
 <td>Not interactive</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>Used for SEO and browser handling.</td>
 </tr>
 <tr>
@@ -800,7 +810,7 @@ this feature is supposed to convey to the user.</li>
 <td>Visual gauge or meter</td>
 <td>Announces "meter" + value</td>
 <td>Swipe to interact</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Announces the current value.</td>
 </tr>
 <tr>
@@ -809,7 +819,7 @@ this feature is supposed to convey to the user.</li>
 <td>Navigation links</td>
 <td>Announces "navigation"</td>
 <td>Rotor to 'landmarks' or swipe to navigate</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognized as a navigation landmark.</td>
 </tr>
 <tr>
@@ -818,7 +828,7 @@ this feature is supposed to convey to the user.</li>
 <td>Content for non-JS enabled browsers</td>
 <td>Reads element content</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>Displayed if JavaScript is disabled.</td>
 </tr>
 <tr>
@@ -827,7 +837,7 @@ this feature is supposed to convey to the user.</li>
 <td>Generic embedded object</td>
 <td>Announces "object"</td>
 <td>Swipe left/right to interact</td>
-<td><svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img"><path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"></path></svg></td>
+<td><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg></td>
 <td>Behavior depends on the embedded content type.</td>
 </tr>
 <tr>
@@ -836,7 +846,7 @@ this feature is supposed to convey to the user.</li>
 <td>Numbered list of items</td>
 <td>Announces "ordered list" + number of items</td>
 <td>Swipe to navigate</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognizes list structure and item count.</td>
 </tr>
 <tr>
@@ -845,7 +855,7 @@ this feature is supposed to convey to the user.</li>
 <td>Grouping of options in a dropdown</td>
 <td>Announces "group" label</td>
 <td>Swipe to navigate options</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognizes option groups within a select menu.</td>
 </tr>
 <tr>
@@ -854,7 +864,7 @@ this feature is supposed to convey to the user.</li>
 <td>Selectable option in a dropdown</td>
 <td>Announces option text</td>
 <td>Swipe to select</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognizes the selected state.</td>
 </tr>
 <tr>
@@ -863,7 +873,7 @@ this feature is supposed to convey to the user.</li>
 <td>Result of a calculation</td>
 <td>Reads the output value</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Announces dynamically updated content.</td>
 </tr>
 <tr>
@@ -872,7 +882,7 @@ this feature is supposed to convey to the user.</li>
 <td>Block of text</td>
 <td>Reads content as normal text</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Treated as regular paragraph text.</td>
 </tr>
 <tr>
@@ -881,7 +891,7 @@ this feature is supposed to convey to the user.</li>
 <td>Responsive image</td>
 <td>Announces selected image</td>
 <td>Swipe to navigate</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Reads the most appropriate image source.</td>
 </tr>
 <tr>
@@ -890,7 +900,7 @@ this feature is supposed to convey to the user.</li>
 <td>Text with preserved whitespace</td>
 <td>Reads content as normal text</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Retains formatting, including line breaks.</td>
 </tr>
 <tr>
@@ -899,7 +909,7 @@ this feature is supposed to convey to the user.</li>
 <td>Progress indicator</td>
 <td>Announces "progress bar" + value</td>
 <td>Swipe to interact</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Announces the current progress value.</td>
 </tr>
 <tr>
@@ -908,7 +918,7 @@ this feature is supposed to convey to the user.</li>
 <td>Short inline quotation</td>
 <td>Announces quotation marks</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognizes start/end of quotes.</td>
 </tr>
 <tr>
@@ -917,7 +927,7 @@ this feature is supposed to convey to the user.</li>
 <td>Ruby text fallback</td>
 <td>Reads content as normal text</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>Displayed if ruby text not supported.</td>
 </tr>
 <tr>
@@ -926,7 +936,7 @@ this feature is supposed to convey to the user.</li>
 <td>Ruby pronunciation guide</td>
 <td>Reads content as normal text</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Reads inline with the main text.</td>
 </tr>
 <tr>
@@ -935,7 +945,7 @@ this feature is supposed to convey to the user.</li>
 <td>Container for ruby text annotations</td>
 <td>Reads the ruby text annotations</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Provides pronunciation guidance inline.</td>
 </tr>
 <tr>
@@ -944,7 +954,7 @@ this feature is supposed to convey to the user.</li>
 <td>Text with a line through it</td>
 <td>Reads content as normal text</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>No unique indication for strikethrough.</td>
 </tr>
 <tr>
@@ -953,7 +963,7 @@ this feature is supposed to convey to the user.</li>
 <td>Sample output from a program</td>
 <td>Reads content as normal text</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>No specific treatment beyond reading.</td>
 </tr>
 <tr>
@@ -962,7 +972,7 @@ this feature is supposed to convey to the user.</li>
 <td>Embedded or external JavaScript</td>
 <td>No aural feedback</td>
 <td>Not interactive</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>Executes without screen reader feedback.</td>
 </tr>
 <tr>
@@ -971,7 +981,7 @@ this feature is supposed to convey to the user.</li>
 <td>Thematic grouping of content</td>
 <td>Announces "region"</td>
 <td>Rotor to 'landmarks'</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognized as a landmark if labeled.</td>
 </tr>
 <tr>
@@ -980,7 +990,7 @@ this feature is supposed to convey to the user.</li>
 <td>Dropdown menu</td>
 <td>Announces "popup button"</td>
 <td>Double-tap to open, swipe to select</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Reads all available options.</td>
 </tr>
 <tr>
@@ -989,7 +999,7 @@ this feature is supposed to convey to the user.</li>
 <td>Less important text</td>
 <td>Reads content as normal text</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>No special emphasis applied.</td>
 </tr>
 <tr>
@@ -998,7 +1008,7 @@ this feature is supposed to convey to the user.</li>
 <td>Source for media elements</td>
 <td>No direct aural feedback</td>
 <td>Not interactive</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>Used within <code>&lt;audio&gt;</code> and <code>&lt;video&gt;</code>.</td>
 </tr>
 <tr>
@@ -1007,7 +1017,7 @@ this feature is supposed to convey to the user.</li>
 <td>Generic inline container</td>
 <td>Reads content as normal text</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>Treated as part of the text flow.</td>
 </tr>
 <tr>
@@ -1016,7 +1026,7 @@ this feature is supposed to convey to the user.</li>
 <td>Important text</td>
 <td>Reads with strong emphasis</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Uses a more assertive voice inflection.</td>
 </tr>
 <tr>
@@ -1025,7 +1035,7 @@ this feature is supposed to convey to the user.</li>
 <td>Embedded stylesheets</td>
 <td>No aural feedback</td>
 <td>Not interactive</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>Applies CSS styles; ignored by screen reader.</td>
 </tr>
 <tr>
@@ -1034,7 +1044,7 @@ this feature is supposed to convey to the user.</li>
 <td>Subscript text</td>
 <td>Reads content as normal text</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>No unique indication of subscript.</td>
 </tr>
 <tr>
@@ -1043,7 +1053,7 @@ this feature is supposed to convey to the user.</li>
 <td>Summary for <code>&lt;details&gt;</code></td>
 <td>Announces "summary"</td>
 <td>Double-tap to expand/collapse</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Acts as a trigger for the <code>&lt;details&gt;</code> element.</td>
 </tr>
 <tr>
@@ -1052,7 +1062,7 @@ this feature is supposed to convey to the user.</li>
 <td>Superscript text</td>
 <td>Reads content as normal text</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>No unique indication of superscript.</td>
 </tr>
 <tr>
@@ -1061,7 +1071,7 @@ this feature is supposed to convey to the user.</li>
 <td>Vector graphics</td>
 <td>Announces "graphic" if labeled</td>
 <td>Swipe to navigate</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Reads accessible labels, if provided.</td>
 </tr>
 <tr>
@@ -1070,7 +1080,7 @@ this feature is supposed to convey to the user.</li>
 <td>Tabular data</td>
 <td>Announces "table with X rows and Y columns"</td>
 <td>Swipe to navigate cells</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Provides structured navigation through rows/columns.</td>
 </tr>
 <tr>
@@ -1079,7 +1089,7 @@ this feature is supposed to convey to the user.</li>
 <td>Table content container</td>
 <td>Included in table navigation</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognized as part of table structure.</td>
 </tr>
 <tr>
@@ -1088,7 +1098,7 @@ this feature is supposed to convey to the user.</li>
 <td>Cell within a table row</td>
 <td>Reads cell content</td>
 <td>Included in table navigation</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Properly linked to headers where applicable.</td>
 </tr>
 <tr>
@@ -1097,7 +1107,7 @@ this feature is supposed to convey to the user.</li>
 <td>Client-side template content</td>
 <td>No aural feedback</td>
 <td>Not interactive</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>Hidden unless instantiated by JavaScript.</td>
 </tr>
 <tr>
@@ -1106,7 +1116,7 @@ this feature is supposed to convey to the user.</li>
 <td>Editable multi-line text area</td>
 <td>Announces "text area"</td>
 <td>Text entry interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Allows multiple lines of input.</td>
 </tr>
 <tr>
@@ -1115,7 +1125,7 @@ this feature is supposed to convey to the user.</li>
 <td>Footer section of a table</td>
 <td>Included in table navigation</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognized as part of table structure.</td>
 </tr>
 <tr>
@@ -1124,7 +1134,7 @@ this feature is supposed to convey to the user.</li>
 <td>Header cell within a table</td>
 <td>Announces "column header" or "row header"</td>
 <td>Included in table navigation</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognizes association with data cells.</td>
 </tr>
 <tr>
@@ -1133,7 +1143,7 @@ this feature is supposed to convey to the user.</li>
 <td>Header section of a table</td>
 <td>Included in table navigation</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognized as part of table structure.</td>
 </tr>
 <tr>
@@ -1142,7 +1152,7 @@ this feature is supposed to convey to the user.</li>
 <td>Date/time representation</td>
 <td>Reads element content</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Displays human-readable time/date.</td>
 </tr>
 <tr>
@@ -1151,7 +1161,7 @@ this feature is supposed to convey to the user.</li>
 <td>Title of the document</td>
 <td>Announces when the page loads</td>
 <td>Not interactive</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Read when the page/tab gains focus.</td>
 </tr>
 <tr>
@@ -1160,7 +1170,7 @@ this feature is supposed to convey to the user.</li>
 <td>Row within a table</td>
 <td>Included in table navigation</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Reads content within each cell of the row.</td>
 </tr>
 <tr>
@@ -1169,7 +1179,7 @@ this feature is supposed to convey to the user.</li>
 <td>Subtitles, captions, or descriptions</td>
 <td>Announces track type when enabled</td>
 <td>Swipe to activate/deactivate</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Used with <code>&lt;audio&gt;</code> and <code>&lt;video&gt;</code> elements.</td>
 </tr>
 <tr>
@@ -1178,7 +1188,7 @@ this feature is supposed to convey to the user.</li>
 <td>Text with underline styling</td>
 <td>Reads content as normal text</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>No unique aural distinction for underline.</td>
 </tr>
 <tr>
@@ -1187,7 +1197,7 @@ this feature is supposed to convey to the user.</li>
 <td>Bullet list</td>
 <td>Announces "list with X items"</td>
 <td>Swipe to navigate list items</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Recognizes and reads list structure.</td>
 </tr>
 <tr>
@@ -1196,7 +1206,7 @@ this feature is supposed to convey to the user.</li>
 <td>Variable or argument in text/code</td>
 <td>Reads element content</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>No unique treatment beyond normal text.</td>
 </tr>
 <tr>
@@ -1205,7 +1215,7 @@ this feature is supposed to convey to the user.</li>
 <td>Embedded video with controls</td>
 <td>Announces "video"</td>
 <td>Double-tap to play/pause</td>
-<td><svg viewBox="0 0 448 512" width="20" aria-label="yes"><path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51 21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0 26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628 0L184 302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg></td>
 <td>Provides full media controls.</td>
 </tr>
 <tr>
@@ -1214,7 +1224,7 @@ this feature is supposed to convey to the user.</li>
 <td>Suggests a line break opportunity</td>
 <td>No direct aural feedback</td>
 <td>No special interaction</td>
-<td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected"><path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg></td>
+<td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
 <td>Breaks are handled visually via CSS/layout.</td>
 </tr>
 </tbody>

--- a/VO-ios.html
+++ b/VO-ios.html
@@ -27,6 +27,52 @@ body {background-color:white}
 </style>
 </head>
 <body>
+<svg style="display:none">
+<symbol id="yes">
+    <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
+    21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
+    26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248
+    6.248-16.379
+    0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
+    0L184
+    302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
+    0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104
+    104c6.249 6.25 16.379 6.25 22.628.001z"></path>
+</symbol>
+<symbol id="no">
+    <path d="M464 32H48C21.5 32 0
+    53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
+    48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
+    12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
+    313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
+    0l-40.5-40.5c-4.8-4.8-4.8-12.6
+    0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
+    0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
+    66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8 4.8
+    12.6 0 17.4L313.3 256l67.1 66.5z"></path>
+</symbol>
+<symbol id="noneE">
+    <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48
+    48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92
+    296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0
+    12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path>
+</symbol>
+<symbol id="unknown">
+    <path d="M504 256c0
+    136.997-111.043 248-248 248S8 392.997 8 256C8 119.083
+    119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497
+    0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415
+    2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008
+    16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797
+    20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363
+    22.667-32.534 33.976C247.128 238.528 216 254.941 216
+    296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
+    12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
+    0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
+    20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
+    46-46c0-25.365-20.635-46-46-46z"></path>
+</symbol>
+</svg>
 <header class="site-head">
   <div class="wrapper">
     <a href="#main" class="cta skip-link" data-cta-variant="secondary">
@@ -49,7 +95,6 @@ body {background-color:white}
 <p><strong>GitHub Repo:</strong> <a href="https://github.com/TetraLogical/screen-reader-HTML-support">screen-reader-HTML-support</a>
 </p>
 <p>Found a bug? Please <a href="https://github.com/TetraLogical/screen-reader-HTML-support/issues">report it</a>. </p>
-</header>
 <main>
 <h2>How HTML elements are supported by screen readers</h2>
 <p> Typical support patterns of HTML elements by screen readers: </p>
@@ -76,49 +121,14 @@ varies from element to element and support for a particular
 element varies between screen reader software. </p>
 <h2>Support legend</h2>
 <ul>
-<li><svg viewBox="0 0 448 512" width="20" aria-label="yes"  class="yes">
-<path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248
-6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104
-104c6.249 6.25 16.379 6.25 22.628.001z"></path> </svg>
+<li><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
 means we have found this feature to be implemented
 interoperably (across multiple browsers)</li>
-<li><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><path d="M464 32H48C21.5 32 0
-53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-0l-40.5-40.5c-4.8-4.8-4.8-12.6
-0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8 4.8
-12.6 0 17.4L313.3 256l67.1 66.5z"></path></svg> means we
+<li><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg> means we
 have found that this feature is not implemented</li>
-<li><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-<path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48
-48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92
-296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0
-12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg>
+<li><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
 means the element has no expected semantics.</li>
-<li><svg viewBox="0 0 512 512" width="20" aria-label="question
-mark" class="unknown" role="img"><path d="M504 256c0
-136.997-111.043 248-248 248S8 392.997 8 256C8 119.083
-119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497
-0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415
-2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008
-16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797
-20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path></svg> means we
+<li><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg> means we
 are unsure whether this feature is supported, this may be due
 to lack of testing or lack of clarity around what 'support' of
 this feature is supposed to convey to the user.</li>
@@ -151,16 +161,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-        <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-        21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-        26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248
-        6.248-16.379
-        0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-        0L184
-        302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-        0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104
-        104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
 <p>Recognizes visited/unvisited state of links.</p>
@@ -179,16 +180,7 @@ this feature is supposed to convey to the user.</li>
         <p>No special interaction</p>
         </td>
         <td>
-            <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><path d="M464 32H48C21.5 32 0
-                53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-                48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-                12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-                313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-                0l-40.5-40.5c-4.8-4.8-4.8-12.6
-                0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-                0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-                66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8 4.8
-                12.6 0 17.4L313.3 256l67.1 66.5z"></path></svg>
+            <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
         </td>
         <td>
         <p>No additional semantics conveyed if title is present.</p>
@@ -203,16 +195,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-    <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><path d="M464 32H48C21.5 32
-    0 53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0
-    48-21.5 48-48V80c0-26.5-21.5-48-48-48zm-83.6
-    290.5c4.8 4.8 4.8 12.6 0 17.4l-40.5 40.5c-4.8
-    4.8-12.6 4.8-17.4 0L256 313.3l-66.5 67.1c-4.8
-    4.8-12.6 4.8-17.4 0l-40.5-40.5c-4.8-4.8-4.8-12.6
-    0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-    0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-    66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-    4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path></svg>
+    <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
 
     </td>
     <td>No additional semantics conveyed</td>
@@ -230,17 +213,7 @@ this feature is supposed to convey to the user.</li>
         Swipe left/right to navigate
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Requires alt for accessibility.</td>
 </tr>
@@ -253,17 +226,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em>, does not announce article</td>
     <td>Rotor to 'articles' Swipe down with one finger to navigate by article</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>No additional semantics conveyed. Documentation states that swipe one finger up should naviagte back through articles, but does not appear to work. article does support aria-describedby and announces "Description..." after visible text.</td>
 </tr>
@@ -280,17 +243,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         <ul>
@@ -306,17 +259,7 @@ this feature is supposed to convey to the user.</li>
     <td>Announces "audio"</td>
     <td>Double-tap to play/pause. Swipe up down with one finger to operate the time scrubber.</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Accessible buttons available in the player. The time scrubber operation is flaky when VoiceOver is enabled.</td>
 </tr>
@@ -327,13 +270,7 @@ this feature is supposed to convey to the user.</li>
     <td>Reads content as normal text</td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No specific emphasis expected.</td>
 </tr>
@@ -345,13 +282,7 @@ this feature is supposed to convey to the user.</li>
     <td>No aural feedback</td>
     <td>Not interactive</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>Typically ignored by VoiceOver.</td>
 </tr>
@@ -362,13 +293,7 @@ this feature is supposed to convey to the user.</li>
     <td>Reads content as normal text</td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No aural impact; structure-only element.</td>
 </tr>
@@ -379,13 +304,7 @@ this feature is supposed to convey to the user.</li>
     <td>Reads content as normal text</td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No special semantics conveyed. Reads text correctly regardless of direction.</td>
 </tr>
@@ -397,17 +316,7 @@ this feature is supposed to convey to the user.</li>
     <td>No special interaction
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>No additional semantics conveyed.</td>
 </tr>
@@ -418,13 +327,7 @@ this feature is supposed to convey to the user.</li>
     <td>Reads content</td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No unique aural feedback; body is implicit.</td>
 </tr>
@@ -435,13 +338,7 @@ this feature is supposed to convey to the user.</li>
     <td>Announces nothing</td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0
-    53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5
-    48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-    0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-    12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No additional semantics conveyed.Treated as one new line, regardless of number of line break elements</td>
 </tr>
@@ -458,17 +355,7 @@ this feature is supposed to convey to the user.</li>
 	    </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Announced as "toggle button" label and state (pressed/unpressed) when button has aria-pressed.</td>
 </tr>
@@ -479,13 +366,7 @@ this feature is supposed to convey to the user.</li>
     <td>Announces "graphic" if aria-label and Role="img" is provided, Other wise ignores canvas</td>
     <td>Focusable via swipe gestures if role="img" present or sub DOM contains content.</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0
-    53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5
-    48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-    0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-    12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td> 
         <ul>
@@ -507,17 +388,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td> 
 <ul>
@@ -533,13 +404,7 @@ this feature is supposed to convey to the user.</li>
     <td>Reads content as normal text</td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0
-    53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5
-    48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-    0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-    12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>
     <p>No semantics conveyed.</p>
@@ -552,13 +417,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0
-    53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5
-    48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-    0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-    12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>
   No unique treatment; read as normal text.
@@ -571,13 +430,7 @@ this feature is supposed to convey to the user.</li>
     <td>No aural indication</td>
     <td>Not directly interactive</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>Impact conveyed through table structure only.</td>
 </tr>
@@ -594,13 +447,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>
         <ul>
@@ -616,13 +463,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interactions</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>Treated as regular text</td>
 </tr>
@@ -637,17 +478,7 @@ this feature is supposed to convey to the user.</li>
         Swipe left/right to focus on input, double-tap to select
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>List of suggestions appear in browser suggestions rather than as a listbox. With VO enabled cannot display listbox.</td>
 </tr>    
@@ -658,17 +489,7 @@ this feature is supposed to convey to the user.</li>
     <td>Announces start of "description list" <em>Element content</em> suffixed with "Description" announces "description list end"</td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Properly grouped with its <code>dt</code>/td>
 </tr>
@@ -679,17 +500,7 @@ this feature is supposed to convey to the user.</li>
     <td>Announces as "deletion" + <em>element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td></td>
 </tr>
@@ -700,17 +511,7 @@ this feature is supposed to convey to the user.</li>
     <td>Announces <code>summary</code> text, button, collapsed or expanded (when details content is visible)</td>
     <td>Double-tap to expand/collapse</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Recognizes expanded/collapsed state.</td>
 </tr>
@@ -721,13 +522,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em> not role</td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No unique treatment beyond reading</td>
 </tr>
@@ -743,17 +538,7 @@ this feature is supposed to convey to the user.</li>
     </td>
     <td>Focus moves to dialog on open</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Recognizes and traps focus within modal dialog. When dialog closed does not return focus to triggering control unless the dialog has an accessible name.</td>
 </tr>
@@ -764,13 +549,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -785,17 +564,7 @@ this feature is supposed to convey to the user.</li>
         Not recognised as a list in rotor navigation
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td></td>
 </tr>
@@ -810,17 +579,7 @@ this feature is supposed to convey to the user.</li>
         Part of list navigation
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Associated with the following <code>dd</code></td>
 </tr>
@@ -831,13 +590,7 @@ this feature is supposed to convey to the user.</li>
     <td>Element content</td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>
         No semantics conveyed. Refer to: <a href="https://www.tpgi.com/screen-readers-support-for-text-level-html-semantics/">Screen 
@@ -855,22 +608,7 @@ this feature is supposed to convey to the user.</li>
        No special interactions
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-                256C8 119.083 119.043 8 256 8s248 111.083 248
-                248zM262.655 90c-54.497 0-89.255 22.957-116.549
-                63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-                26.31c5.205 3.947 12.621 3.008 16.665-2.122
-                17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-                45.698 13.148 45.698 32.958 0 14.976-12.363
-                22.667-32.534 33.976C247.128 238.528 216 254.941 216
-                296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-                12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-                0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-                20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-                46-46c0-25.365-20.635-46-46-46z">
-            </path>
-        </svg>    
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>    
     </td>
     <td>
         
@@ -889,17 +627,7 @@ this feature is supposed to convey to the user.</li>
         keys navigation keys for the child control.
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Only when <code>fieldset</code> has an accessible name via <code>legend</code> or other method.</td>
 </tr>
@@ -910,17 +638,7 @@ this feature is supposed to convey to the user.</li>
     <td>Element content</td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>&nbsp;</td>
 </tr>
@@ -931,17 +649,7 @@ this feature is supposed to convey to the user.</li>
     <td>VoiceOver announces the content of the <figure> element based on what's inside it. For example, if the <code>figure</code> element wraps around an image, VoiceOver will read the image along with its accessible name, typically provided via the alt attribute.</td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>"Figure" is not announced if the element does not have an accessible name or contain a <code>&lt;figcaption&gt;</code> element.</td>
 </tr>
@@ -958,17 +666,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         <ul>
@@ -986,17 +684,7 @@ this feature is supposed to convey to the user.</li>
         No special instructions
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -1009,17 +697,7 @@ this feature is supposed to convey to the user.</li>
        No special interaction
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Identifies heading level and text.</td>
 </tr>
@@ -1030,13 +708,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -1053,17 +725,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         <ul>
@@ -1079,17 +741,7 @@ this feature is supposed to convey to the user.</li>
     <td>Announced as, "Separator, dimmed"</td>
     <td>No special command</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>If an accessible name is provided, the element is announced as "Seperator, accessible name, dimmer"</td>
 </tr>
@@ -1100,13 +752,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No semantics expected.</td>
 </tr>
@@ -1117,13 +763,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No semantics conveyed.</td>
 </tr>
@@ -1141,21 +781,7 @@ this feature is supposed to convey to the user.</li>
     Swipe left/right to enter <code>frame</code>.
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>
         <ul>
@@ -1183,17 +809,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         <ul>
@@ -1217,17 +833,7 @@ this feature is supposed to convey to the user.</li>
        
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Announces <code>title</code> attribute in addition to label or <code>value</code> if present</td>
 </tr>
@@ -1244,17 +850,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         <ul>
@@ -1276,21 +872,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
- <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+ <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>Opens a colour selection grid when activated. "Double tap to activate" is not announced by VO.</td>
 </tr>
@@ -1307,18 +889,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-            <path d="M464 32H48C21.5 32 0
-            53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-            12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-            313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-            0l-40.5-40.5c-4.8-4.8-4.8-12.6
-            0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-            0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-            66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8 4.8
-            12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     </td>
     <td>
         Opens a date selection picker when activated. "Double tap to activate" is not announced by VO.
@@ -1337,21 +908,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>Treated as a regular text field, announces "Double tap to edit"</td>
 </tr>
@@ -1368,17 +925,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Opens a file selection picker when activated.</td>
 </tr>
@@ -1389,12 +936,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 
-            48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 
-            296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -1411,17 +953,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>VoiceOver on-device image recognition settings don't work on <code>input type="image"</code> as they are not recognised as images</td>
 </tr>
@@ -1438,21 +970,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>
         <ul>
@@ -1474,21 +992,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>
          <ul>
@@ -1510,17 +1014,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         <ul>
@@ -1545,17 +1039,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Recognizes position within radio group</td>
 </tr>
@@ -1572,17 +1056,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Resets all form inputs to their default value</td>
 </tr>
@@ -1603,21 +1077,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No special interaction</td>
 </tr>
@@ -1634,17 +1094,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Submits the form data to the server</td>
 </tr>
@@ -1661,21 +1111,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>
         <ul>
@@ -1701,17 +1137,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Announces "Double tap to edit"</td>
 </tr>
@@ -1728,18 +1154,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-            <path d="M464 32H48C21.5 32 0
-            53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-            12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-            313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-            0l-40.5-40.5c-4.8-4.8-4.8-12.6
-            0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-            0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-            66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8 4.8
-            12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     </td>
     <td>
         <ul>
@@ -1761,21 +1176,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
      <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>
         <ul>
@@ -1791,18 +1192,7 @@ this feature is supposed to convey to the user.</li>
     <td>Announces as "insertion" + "deletion" + <em>element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627
-            22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         
@@ -1815,18 +1205,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-            <path d="M464 32H48C21.5 32 0
-            53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-            12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-            313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-            0l-40.5-40.5c-4.8-4.8-4.8-12.6
-            0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-            0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-            66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-            4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -1837,17 +1216,7 @@ this feature is supposed to convey to the user.</li>
     <td>Label content announced when the corresponding form control has focus</td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>No semantics beyond association with input conveyed</td>
 </tr>
@@ -1860,17 +1229,7 @@ this feature is supposed to convey to the user.</li>
     <td>Announces as first item of fieldset</td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Serves as the group label for a group of form controls. Refer to the <a href="#toc-f">fieldset</a> element</td>
 </tr>
@@ -1897,17 +1256,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>  
         <ul>
@@ -1923,12 +1272,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special interaction</td>
     <td>      
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 
-            48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 
-            296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -1945,21 +1289,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantic feedback. Landmarks need to be added to the iOS VO rotor menu items before it is accessible. This can be added in the VoiceOver Settings, under Rotor.</td>
 </tr>
@@ -1970,12 +1300,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 
-            48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 
-            296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -1986,17 +1311,7 @@ this feature is supposed to convey to the user.</li>
     <td>Announces as <em>element content</em> + "highlighted"</td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Content provided via an <code>aria-label</code> or <code>aria-labelledby</code> is not announced.</td>
 </tr>
@@ -2007,12 +1322,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 
-            48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 
-            296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -2023,21 +1333,7 @@ this feature is supposed to convey to the user.</li>
     <td>Announces as label content, if present + the current percentage value (e.g. "83%")</td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>If fallback content is provided within the <code>&lt;meter&gt;</code> element, the fallback content is announced 
         instead of the value.
@@ -2056,17 +1352,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Landmarks need to be added to the iOS VO rotor menu items before it is accessible. This can be added in the VoiceOver Settings, under Rotor.</td>
 </tr>
@@ -2077,12 +1363,7 @@ this feature is supposed to convey to the user.</li>
     <td>Content of <code>&lt;noscript&gt;</code> element read if JavaScript is not available/enabled</td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 
-            48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 
-            296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>Ignored when JavaScript is enabled.</td>
 </tr>
@@ -2094,21 +1375,7 @@ this feature is supposed to convey to the user.</li>
     <td>No special interaction
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>Support varies depending on object type. If fallback content is provided within the <code>object</code> element tags then this is announced instead if the data source is broken.</code></td>
 </tr>
@@ -2125,17 +1392,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         <ul>
@@ -2151,21 +1408,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>Swipe left/right within dropdown to <code>optgroup</code> content</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>
         No semantics conveyed
@@ -2178,17 +1421,7 @@ this feature is supposed to convey to the user.</li>
     <td>Announced as "selected", if the option is currently selected + <code>option</code> content + "button"</td>
     <td>Swipe up/down within dropdown, double-tap to select</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Double-tap on <code>select</code> element to expand the list of options.</td>
 </tr>
@@ -2199,21 +1432,7 @@ this feature is supposed to convey to the user.</li>
     <td>Reads output value</td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2224,17 +1443,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2245,12 +1454,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 
-            48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 
-            296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -2261,12 +1465,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 
-            48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 
-            296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -2277,17 +1476,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>No semantics conveyed but announced with a change in intonation</td>
 </tr>
@@ -2298,21 +1487,7 @@ this feature is supposed to convey to the user.</li>
     <td>Announced as label, if present + current value as a percentage (e.g. "22%")</td> 
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>
         No semantics conveyed.
@@ -2325,21 +1500,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed but announced in a different intonation.</td>
 </tr>
@@ -2350,20 +1511,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img"><path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2374,21 +1522,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2399,21 +1533,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2424,21 +1544,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2449,21 +1555,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2474,17 +1566,7 @@ this feature is supposed to convey to the user.</li>
     <td>Announced as "deletion" + <em>element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td></td>
 </tr>
@@ -2495,21 +1577,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2520,12 +1588,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 
-            48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 
-            296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -2549,21 +1612,7 @@ this feature is supposed to convey to the user.</li>
        No special interaction.
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>
         <ul>
@@ -2585,17 +1634,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         <ul>
@@ -2611,21 +1650,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-                256C8 119.083 119.043 8 256 8s248 111.083 248
-                248zM262.655 90c-54.497 0-89.255 22.957-116.549
-                63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-                26.31c5.205 3.947 12.621 3.008 16.665-2.122
-                17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-                45.698 13.148 45.698 32.958 0 14.976-12.363
-                22.667-32.534 33.976C247.128 238.528 216 254.941 216
-                296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-                12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-                0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-                20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-                46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2639,17 +1664,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -2660,11 +1675,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 
-            48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 
-            5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2675,21 +1686,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2700,11 +1697,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 
-            48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 
-            5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -2715,21 +1708,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2749,17 +1728,7 @@ this feature is supposed to convey to the user.</li>
     </td>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-        <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-        21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-        26.51-21.49 48-48
-        48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-        0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-        0L184
-        302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-        0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-        22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Serves as a trigger for expanding/collapsing <code>&lt;details&gt;</code> section.</td>
 </tr>
@@ -2770,21 +1739,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2801,21 +1756,7 @@ this feature is supposed to convey to the user.</li>
     <td>No special interaction
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td> 
         <ul>
@@ -2844,17 +1785,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         <ul>
@@ -2870,11 +1801,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 
-            48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 
-            5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2891,17 +1818,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Announces row and column number of the cell</td>
 </tr>
@@ -2912,11 +1829,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 
-            48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 
-            5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -2933,17 +1846,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Announces "double-tap to edit"</td>
 </tr>
@@ -2957,21 +1860,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em>></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2982,17 +1871,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>Announces as cell content + "column/row header"</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>VO recognises row/column headers</td>
 </tr>
@@ -3003,18 +1882,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-            <path d="M464 32H48C21.5 32 0
-            53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-            12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-            313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-            0l-40.5-40.5c-4.8-4.8-4.8-12.6
-            0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-            0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-            66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-            4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -3025,18 +1893,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-            <path d="M464 32H48C21.5 32 0
-            53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-            12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-            313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-            0l-40.5-40.5c-4.8-4.8-4.8-12.6
-            0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-            0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-            66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-            4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -3047,17 +1904,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>In Safari, navigate to tab view from the toolbar. VO will announce page title content + "tab, X of Y", Y being the total number of pages and X the item number of the current page</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td></td>
 </tr>
@@ -3068,17 +1915,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -3089,21 +1926,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Caption display control</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -3114,18 +1937,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-            <path d="M464 32H48C21.5 32 0
-            53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-            12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-            313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-            0l-40.5-40.5c-4.8-4.8-4.8-12.6
-            0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-            0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-            66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-            4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -3142,17 +1954,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         <ul>
@@ -3168,18 +1970,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-            <path d="M464 32H48C21.5 32 0
-                53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-                48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-                12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-                313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-                0l-40.5-40.5c-4.8-4.8-4.8-12.6
-                0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-                0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-                66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-                4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -3190,21 +1981,7 @@ this feature is supposed to convey to the user.</li>
     <td>Announces as video duration (e.g. "37 seconds") "video playback, elapsed time X seconds", where X is the current timestamp</td>
     <td>Swipe left/right to focus with VO, double-tap to play/pause</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>Announces "double-tap to play or pause"</td>
 </tr>
@@ -3215,12 +1992,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>None expected</em></td>
     <td>No special interaction</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 
-            48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 
-            296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 
-            5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>

--- a/VO-mac.html
+++ b/VO-mac.html
@@ -27,6 +27,52 @@ body {background-color:white}
 </style>
 </head>
 <body>
+<svg hidden>
+<symbol id="yes">
+    <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
+    21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
+    26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248
+    6.248-16.379
+    0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
+    0L184
+    302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
+    0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104
+    104c6.249 6.25 16.379 6.25 22.628.001z"></path>
+</symbol>
+<symbol id="no">
+    <path d="M464 32H48C21.5 32 0
+    53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
+    48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
+    12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
+    313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
+    0l-40.5-40.5c-4.8-4.8-4.8-12.6
+    0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
+    0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
+    66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8 4.8
+    12.6 0 17.4L313.3 256l67.1 66.5z"></path>
+</symbol>
+<symbol id="noneE">
+    <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48
+    48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92
+    296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0
+    12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path>
+</symbol>
+<symbol id="unknown">
+    <path d="M504 256c0
+    136.997-111.043 248-248 248S8 392.997 8 256C8 119.083
+    119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497
+    0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415
+    2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008
+    16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797
+    20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363
+    22.667-32.534 33.976C247.128 238.528 216 254.941 216
+    296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
+    12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
+    0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
+    20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
+    46-46c0-25.365-20.635-46-46-46z"></path>
+</symbol>
+</svg>
 <header class="site-head">
   <div class="wrapper">
     <a href="#main" class="cta skip-link" data-cta-variant="secondary">
@@ -76,49 +122,14 @@ varies from element to element and support for a particular
 element varies between screen reader software. </p>
 <h2>Support legend</h2>
 <ul>
-<li><svg viewBox="0 0 448 512" width="20" aria-label="yes"  class="yes">
-<path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248
-6.248-16.379
-0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-0L184
-302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104
-104c6.249 6.25 16.379 6.25 22.628.001z"></path> </svg>
+<li><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
 means we have found this feature to be implemented
 interoperably (across multiple browsers)</li>
-<li><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><path d="M464 32H48C21.5 32 0
-53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-0l-40.5-40.5c-4.8-4.8-4.8-12.6
-0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8 4.8
-12.6 0 17.4L313.3 256l67.1 66.5z"></path></svg> means we
+<li><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no"></svg> means we
 have found that this feature is not implemented</li>
-<li><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-<path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48
-48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92
-296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0
-12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> </svg>
+<li><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
 means the element has no expected semantics.</li>
-<li><svg viewBox="0 0 512 512" width="20" aria-label="question
-mark" class="unknown" role="img"><path d="M504 256c0
-136.997-111.043 248-248 248S8 392.997 8 256C8 119.083
-119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497
-0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415
-2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008
-16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797
-20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363
-22.667-32.534 33.976C247.128 238.528 216 254.941 216
-296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-46-46c0-25.365-20.635-46-46-46z"></path></svg> means we
+<li><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg> means we
 are unsure whether this feature is supported, this may be due
 to lack of testing or lack of clarity around what 'support' of
 this feature is supposed to convey to the user.</li>
@@ -152,16 +163,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-        <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-        21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-        26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248
-        6.248-16.379
-        0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-        0L184
-        302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-        0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104
-        104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>
 <p>VoiceOver recognizes visited/unvisited state of links.</p>
@@ -178,16 +180,7 @@ this feature is supposed to convey to the user.</li>
         <p>No special commands</p>
         </td>
         <td>
-             <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-             <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48 48zm-204.686-98.059l184-184c6.248-6.248
-            6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104
-            104c6.249 6.25 16.379 6.25 22.628.001z"></path></svg>
+            <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
         </td>
         <td>
         <p>Expands abbreviation if <code>title</code> attribute is present, announces as "group".</p>
@@ -202,16 +195,7 @@ this feature is supposed to convey to the user.</li>
     <td>Reads content as plain text</td>
     <td>No special commands</td>
     <td>
-    <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><path d="M464 32H48C21.5 32
-    0 53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0
-    48-21.5 48-48V80c0-26.5-21.5-48-48-48zm-83.6
-    290.5c4.8 4.8 4.8 12.6 0 17.4l-40.5 40.5c-4.8
-    4.8-12.6 4.8-17.4 0L256 313.3l-66.5 67.1c-4.8
-    4.8-12.6 4.8-17.4 0l-40.5-40.5c-4.8-4.8-4.8-12.6
-    0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-    0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-    66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-    4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path></svg>
+    <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no"></svg>
 
     </td>
     <td>No additional semantics conveyed</td>
@@ -230,17 +214,7 @@ this feature is supposed to convey to the user.</li>
 
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Requires alt attribute for accessibility.</td>
 </tr>
@@ -256,17 +230,7 @@ this feature is supposed to convey to the user.</li>
 
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Recognizes the start and end of articles.</td>
 </tr>
@@ -282,17 +246,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Recognized as complementary region.</td>
 </tr>
@@ -312,22 +266,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-                256C8 119.083 119.043 8 256 8s248 111.083 248
-                248zM262.655 90c-54.497 0-89.255 22.957-116.549
-                63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-                26.31c5.205 3.947 12.621 3.008 16.665-2.122
-                17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-                45.698 13.148 45.698 32.958 0 14.976-12.363
-                22.667-32.534 33.976C247.128 238.528 216 254.941 216
-                296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-                12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-                0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-                20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-                46-46c0-25.365-20.635-46-46-46z">
-            </path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
     </td>
     <td>Accessible buttons available in the player. Announcements are inconsistent across browsers.</td>
 </tr>
@@ -338,13 +277,7 @@ this feature is supposed to convey to the user.</li>
     <td>Reads content as normal text</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>No specific emphasis expected.</td>
 </tr>
@@ -356,13 +289,7 @@ this feature is supposed to convey to the user.</li>
     <td>No aural interaction</td>
     <td>Not interactive</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>Typically ignored by VoiceOver.</td>
 </tr>
@@ -373,13 +300,7 @@ this feature is supposed to convey to the user.</li>
     <td>Reads content as normal text</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>No aural impact; structure-only element.</td>
 </tr>
@@ -390,13 +311,7 @@ this feature is supposed to convey to the user.</li>
     <td>Reads content as normal text</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>No special semantics conveyed. Reads text correctly regardless of direction.</td>
 </tr>
@@ -408,17 +323,7 @@ this feature is supposed to convey to the user.</li>
     <td>No special commands
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>No additional semantics conveyed.</td>
 </tr>
@@ -429,13 +334,7 @@ this feature is supposed to convey to the user.</li>
     <td>Reads content</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>No unique aural feedback; body is implicit.</td>
 </tr>
@@ -446,13 +345,7 @@ this feature is supposed to convey to the user.</li>
     <td>No aural interaction</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0
-    53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5
-    48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-    0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-    12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>No additional semantics conveyed.Treated as one new line, regardless of number of line break elements</td>
 </tr>
@@ -470,17 +363,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Recognizes the button label and, if provided, state (pressed/unpressed) when button has <code>aria-pressed</code> attribute.</td>
 </tr>
@@ -493,13 +376,7 @@ this feature is supposed to convey to the user.</li>
   <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Right/Left</kbd>  arrow to navigate, focusable via VO navigation
 </td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0
-    53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5
-    48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-    0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-    12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td> 
         <ul>
@@ -527,17 +404,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>The caption linked to the table it describes</td>
 </tr>
@@ -548,13 +415,7 @@ this feature is supposed to convey to the user.</li>
     <td>Reads content as normal text</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0
-    53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5
-    48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-    0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-    12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>
     <p>No specific aural emphasis.</p>
@@ -567,13 +428,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0
-    53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5
-    48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-    0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-    12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>
         No additional semantics conveyed; read as normal text.
@@ -586,13 +441,7 @@ this feature is supposed to convey to the user.</li>
     <td>No aural indication</td>
     <td>Not directly interactive</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>Impact conveyed through table structure only.</td>
 </tr>
@@ -603,13 +452,7 @@ this feature is supposed to convey to the user.</li>
     <td>No aural indication</td>
     <td>Not directly interactive</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>Structure-enhancing, with no direct aural output.</td>
 </tr>
@@ -620,13 +463,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commandss</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>Treated as regular text</td>
 </tr>
@@ -644,17 +481,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>
         <ul>
@@ -675,17 +502,7 @@ this feature is supposed to convey to the user.</li>
 
         </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Linked with its associated <code>dt</code>, which is announced prior to the <code>dd</code> suffixed with "term" </td>
 </tr>
@@ -696,22 +513,7 @@ this feature is supposed to convey to the user.</li>
     <td>Announces "deletion" before deleted text when included as part of a tag with plain text, otherwise no aural indication</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-                256C8 119.083 119.043 8 256 8s248 111.083 248
-                248zM262.655 90c-54.497 0-89.255 22.957-116.549
-                63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-                26.31c5.205 3.947 12.621 3.008 16.665-2.122
-                17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-                45.698 13.148 45.698 32.958 0 14.976-12.363
-                22.667-32.534 33.976C247.128 238.528 216 254.941 216
-                296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-                12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-                0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-                20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-                46-46c0-25.365-20.635-46-46-46z">
-            </path>
-        </svg>    
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>    
     </td>
     <td>
 Support is inconsistent across browsers and "deletion" is only ever announced when part of a tag with plain text
@@ -731,17 +533,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Recognizes expanded/collapsed state.</td>
 </tr>
@@ -752,13 +544,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>No additional semantics conveyed</td>
 </tr>
@@ -772,17 +558,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     </ul>
     <td>Focus moved to dialog when opened</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Recognizes and traps focus within modal dialog</td>
 </tr>
@@ -793,13 +569,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>No semantics conveyed unless ARIA roles are provided</td>
 </tr>
@@ -816,17 +586,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Identifies number of items within the <code>dl</code> list</td>
 </tr>
@@ -846,17 +606,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         Part of list navigation
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Associated with the following <code>dd</code></td>
 </tr>
@@ -867,13 +617,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td>Element content</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>
         No semantics conveyed. Refer to: <a href="https://www.tpgi.com/screen-readers-support-for-text-level-html-semantics/">Screen 
@@ -896,22 +640,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
        
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-                256C8 119.083 119.043 8 256 8s248 111.083 248
-                248zM262.655 90c-54.497 0-89.255 22.957-116.549
-                63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-                26.31c5.205 3.947 12.621 3.008 16.665-2.122
-                17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-                45.698 13.148 45.698 32.958 0 14.976-12.363
-                22.667-32.534 33.976C247.128 238.528 216 254.941 216
-                296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-                12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-                0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-                20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-                46-46c0-25.365-20.635-46-46-46z">
-            </path>
-        </svg>    
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>    
     </td>
     <td>
         <ul>
@@ -935,17 +664,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Only when <code>fieldset</code> has an accessible name via <code>legend</code> or other method</td>
 </tr>
@@ -956,17 +675,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Announces when associated with a figure.</td>
 </tr>
@@ -987,17 +696,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>
     <ul>
@@ -1018,17 +717,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>
         <ul>
@@ -1055,17 +744,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -1078,17 +757,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
        <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Command</kbd> + <kbd>H</kbd> to navigate to next heading
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Identifies heading level and text</td>
 </tr>
@@ -1099,13 +768,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -1121,17 +784,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>  
          <ul>
@@ -1151,17 +804,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Properly indicates a thematic break</td>
 </tr>
@@ -1172,13 +815,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>No semantics expected.</td>
 </tr>
@@ -1189,13 +826,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>No semantics conveyed.</td>
 </tr>
@@ -1222,17 +853,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Recognizes frame title when present</td>
 </tr>
@@ -1254,17 +875,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Reads alt attribute content if present.</td>
 </tr>
@@ -1277,17 +888,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Space</kbd>  to activate
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Recognizes button type and label</td>
 </tr>
@@ -1300,17 +901,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Space</kbd>  to check/uncheck
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Identifies the label and state</td>
 </tr>
@@ -1323,17 +914,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Space</kbd>  to open colour picker
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Allows selection of colours from the palette</td>
 </tr>
@@ -1346,17 +927,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Shift</kbd> + <kbd>Down</kbd> Arrow to edit date area, + <kbd>Right/Left</kbd> Arrows to navigate between date fields and <kbd>Up/Down</kbd> arrows to adjust stepper
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>
         
@@ -1372,21 +943,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
 
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
     </td>
     <td>Treated as a regular text field</td>
 </tr>
@@ -1399,17 +956,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
 	    <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Space</kbd>  to open file selection control
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>
         <ul>
@@ -1425,17 +972,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Used for form data; ignored by VoiceOver</td>
 </tr>
@@ -1451,17 +988,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Space</kbd>  to activate
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>In Chrome, announces "edit text" when input is focused</td>
 </tr>
@@ -1477,17 +1004,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Editable text field when focused with VO or the incremental stepper can be interacted with by use of <kbd>Up/Down</kbd> arrow keys</td>
 </tr>
@@ -1501,17 +1018,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
 
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>
         <ul>
@@ -1531,17 +1038,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Space</kbd>  to select radio button
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Recognizes position within radio group</td>
 </tr>
@@ -1557,17 +1054,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>
         <p>Allows setting a value within a defined range. Slider value announced as it changes.</p>
@@ -1582,17 +1069,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Space</kbd>  to activate
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Resets all form inputs to their default values</td>
 </tr>
@@ -1610,21 +1087,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
 
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
     </td>
     <td>No special commands</td>
 </tr>
@@ -1637,17 +1100,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Space</kbd>  to activate
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Submits the form data to the server</td>
 </tr>
@@ -1661,17 +1114,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
 
     </td>
     <td>
-    <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Announces "edit text" when input is focused</td>
 </tr>
@@ -1694,17 +1137,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
 
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Announces "edit text" when input is focused</td>
 </tr>
@@ -1715,17 +1148,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td>Announces current time value + "time area"</td>
       <td><kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Shift</kbd> + <kbd>Down</kbd> Arrow to edit time values, <kbd>Up/Down</kbd> Arrow keys to increase/decrease stepper value/td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Provides an hour/minute input interface.</td>
 </tr>
@@ -1739,17 +1162,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
 
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Announces "edit text" when input is focused</td>
 </tr>
@@ -1760,21 +1173,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td>Announces "insertion" before inserted text when included as part of a tag with plain text, otherwise no aural indication</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
     </td>
     <td>
         Support was inconsistent across browsers and "insertion" is only ever announced when part of a tag with plain text 
@@ -1787,18 +1186,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td>Reads content as plain text</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-            <path d="M464 32H48C21.5 32 0
-            53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-            12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-            313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-            0l-40.5-40.5c-4.8-4.8-4.8-12.6
-            0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-            0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-            66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-            4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no"></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -1813,17 +1201,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>No semantics beyond association with input conveyed</td>
 </tr>
@@ -1836,17 +1214,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td>Legend content is announced as the group label for a group of related controls when one of the controls is first focused in the group.</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Serves as the group label for a group of form controls. Refer to the <a href="#toc-f">fieldset</a> element</td>
 </tr>
@@ -1869,17 +1237,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
        <kbd>Control</kbd> + <kbd>Option</kbd> + Right Arrow to navigate
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Announces total item count and position of list items within list</td>
 </tr>
@@ -1889,13 +1247,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td>Link metadata</td>
     <td><em>None expected</em></td>
     <td>No special commands</td>
-    <td><svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5
-            48 48 48h352c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6
-            0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg></td>
+    <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg></td>
     <td>No UI</td>
 </tr>
 <tr id="toc-m" tabindex="-1">
@@ -1910,21 +1262,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
     </td>
     <td>Identified as a main landmark region</td>
 </tr>
@@ -1935,12 +1273,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 
-            48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 
-            296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -1953,17 +1286,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     </td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>If an <code>aria-label</code> is provided then VO recognises the start and end of highlighted content</td>
 </tr>
@@ -1974,12 +1297,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 
-            48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 
-            296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -1990,21 +1308,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td>Announces as current value + fallback content/accessible name + "level indicator" </td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
     </td>
     <td>
         <ul>
@@ -2031,17 +1335,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Identified as a navigation landmark</td>
 </tr>
@@ -2052,12 +1346,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td>Content of <code>&lt;noscript&gt;</code> element read if JavaScript is not available/enabled</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 
-            48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 
-            296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>Ignored when JavaScript is enabled.</td>
 </tr>
@@ -2075,21 +1364,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
     </td>
     <td>
         <ul>
@@ -2111,17 +1386,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Announces list structure and number of items</td>
 </tr>
@@ -2132,21 +1397,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td>No aural indication</td>
     <td><kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Space</kbd>  to expand/collapse options list box</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
     </td>
     <td>
         When <code>optgroup</code> element is labelled by an <code>aria-label</code>/<code>aria-labelledby</code> the label content is announced as "dimmed"
@@ -2159,17 +1410,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td>Announced as option content + checkmark if currently selected</td>
     <td><kbd>Up/Down</kbd> arrow keys to navigate options</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Use <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Space</kbd>  to expand/collapse options list</td>
 </tr>
@@ -2185,21 +1426,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     </td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg\s+viewBox="0\s+0\s+512\s+512"\s+width="20"\s+aria-label="question\s+mark"\s+class="unknown"\s+role="img">\s+<path\s+d="M504\s+256c0\s+136\.997-111\.043\s+248-248\s+248S8\s+392\.997\s+8\s+256C8\s+119\.083\s+119\.043\s+8\s+256\s+8s248\s+111\.083\s+248\s+248zM262\.655\s+90c-54\.497\s+0-89\.255\s+22\.957-116\.549\s+63\.758-3\.536\s+5\.286-2\.353\s+12\.415\s+2\.715\s+16\.258l34\.699\s+26\.31c5\.205\s+3\.947\s+12\.621\s+3\.008\s+16\.665-2\.122\s+17\.864-22\.658\s+30\.113-35\.797\s+57\.303-35\.797\s+20\.429\s+0\s+45\.698\s+13\.148\s+45\.698\s+32\.958\s+0\s+14\.976-12\.363\s+22\.667-32\.534\s+33\.976C247\.128\s+238\.528\s+216\s+254\.941\s+216\s+296v4c0\s+6\.627\s+5\.373\s+12\s+12\s+12h56c6\.627\s+0\s+12-5\.373\s+12-12v-1\.333c0-28\.462\s+83\.186-29\.647\s+83\.186-106\.667\s+0-58\.002-60\.165-102-116\.531-102zM256\s+338c-25\.365\s+0-46\s+20\.635-46\s+46\s+0\s+25\.364\s+20\.635\s+46\s+46\s+46s46-20\.636\s+46-46c0-25\.365-20\.635-46-46-46z"><\/path>\s+<\/svg>
     </td>
     <td>VO only recognises the element as "output/status" if the <code>output</code> element has an accessible name. Otherwise, the semantics are ignored and only the value is announced.</td>
 </tr>
@@ -2212,17 +1439,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>P</kbd> to read paragraph
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>No aural semantics.</td>
 </tr>
@@ -2233,12 +1450,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 
-            48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 
-            296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -2249,12 +1461,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 
-            48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 
-            296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -2265,12 +1472,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-       <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 
-            48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 
-            296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+       <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2281,17 +1483,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td>Announced as accessible name (if present) + current percentage value + "progress indicator"
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>
         VO does not announce the new value of the progress bar if the <code>value</code> attribute is updated
@@ -2304,21 +1496,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
     </td>
     <td>
         <ul>
@@ -2334,20 +1512,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img"><path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2358,21 +1523,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2383,21 +1534,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2408,21 +1545,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2433,21 +1556,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2458,18 +1567,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-            <path d="M464 32H48C21.5 32 0
-            53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-            12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-            313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-            0l-40.5-40.5c-4.8-4.8-4.8-12.6
-            0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-            0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-            66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-            4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no"></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2480,21 +1578,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
     </td>
     <td>     
         <ul>
@@ -2510,12 +1594,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 
-            48 48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 
-            296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 5.4 
-            12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -2538,17 +1617,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-            </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>No semantics conveyed unless the section has an accessible name, in which case VO treats the it as a landmark region.</td>
 </tr>
@@ -2571,17 +1640,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Provides list of options</td>
 </tr>
@@ -2592,21 +1651,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-                256C8 119.083 119.043 8 256 8s248 111.083 248
-                248zM262.655 90c-54.497 0-89.255 22.957-116.549
-                63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-                26.31c5.205 3.947 12.621 3.008 16.665-2.122
-                17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-                45.698 13.148 45.698 32.958 0 14.976-12.363
-                22.667-32.534 33.976C247.128 238.528 216 254.941 216
-                296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-                12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-                0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-                20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-                46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2620,17 +1665,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -2641,11 +1676,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 
-            48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 
-            5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2656,21 +1687,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
     </td>
     <td>  
         <ul>
@@ -2686,11 +1703,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 
-            48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 
-            5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -2701,21 +1714,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
     </td>
     <td>   
         <ul>
@@ -2745,17 +1744,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-        <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-        21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-        26.51-21.49 48-48
-        48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-        0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-        0L184
-        302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-        0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-        22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Serves as a trigger for expanding/collapsing <code>&lt;details&gt;</code> section.</td>
 </tr>
@@ -2766,21 +1755,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
     </td>
     <td>
         <ul>
@@ -2806,21 +1781,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
     </td>
     <td>In Safari, the standard keyboard shortcut <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Command</kbd> + <kbd>G</kbd> navigates to individual polygon elements within the <code>&lt;svg&gt;</code></td>
 </tr>
@@ -2844,17 +1805,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>
         <ul>
@@ -2871,11 +1822,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 
-            48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 
-            5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2891,17 +1838,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Announces corresponding header if programmatically associated.</td>
 </tr>
@@ -2912,11 +1849,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h352c26.5 0 
-            48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 296c-6.6 0-12-5.4-12-12v-56c0-6.6 
-            5.4-12 12-12h264c6.6 0 12 5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path> 
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -2934,17 +1867,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Announces "edit text" when input is focused</td>
 </tr>
@@ -2958,18 +1881,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-         <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-            <path d="M464 32H48C21.5 32 0
-            53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-            12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-            313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-            0l-40.5-40.5c-4.8-4.8-4.8-12.6
-            0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-            0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-            66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-            4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-        </svg>
+         <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no"></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2980,18 +1892,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special command. Reachable using standard table cell reading keystrokes.</td>
     <td>
-         <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-            <path d="M464 32H48C21.5 32 0
-            53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-            12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-            313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-            0l-40.5-40.5c-4.8-4.8-4.8-12.6
-            0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-            0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-            66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-            4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-        </svg>
+         <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no"></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -3002,18 +1903,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-         <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-            <path d="M464 32H48C21.5 32 0
-            53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-            12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-            313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-            0l-40.5-40.5c-4.8-4.8-4.8-12.6
-            0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-            0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-            66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-            4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-        </svg>
+         <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no"></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -3024,21 +1914,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td>Announced as <em>element content</em>, or in Safari, accessible name + <em>element content</em> + "group", if element has an accessible name through an <code>aria-label/aria-labelledby</code> attribute</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
     </td>
     <td>In Safari, content in <code>time</code> element is repeated twice</td>
 </tr>
@@ -3054,21 +1930,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
         
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -3079,17 +1941,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td><kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>R</kbd> to read all cell content in current row</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -3100,21 +1952,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Caption display control</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -3125,18 +1963,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-            <path d="M464 32H48C21.5 32 0
-            53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-            48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-            12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-            313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-            0l-40.5-40.5c-4.8-4.8-4.8-12.6
-            0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-            0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-            66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-            4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no"></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -3152,17 +1979,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" aria-label="yes" class="yes">
-            <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
-            21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
-            26.51-21.49 48-48
-            48zm-204.686-98.059l184-184c6.248-6.248 6.248-16.379
-            0-22.627l-22.627-22.627c-6.248-6.248-16.379-6.249-22.628
-            0L184
-            302.745l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628
-            0l-22.627 22.627c-6.248 6.248-6.248 16.379 0
-            22.627l104 104c6.249 6.25 16.379 6.25 22.628.001z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
     </td>
     <td>Announces list structure and number of items</td>
 </tr>
@@ -3174,18 +1991,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     </td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no">
-            <path d="M464 32H48C21.5 32 0
-                53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5
-                48-48V80c0-26.5-21.5-48-48-48zm-83.6 290.5c4.8 4.8 4.8
-                12.6 0 17.4l-40.5 40.5c-4.8 4.8-12.6 4.8-17.4 0L256
-                313.3l-66.5 67.1c-4.8 4.8-12.6 4.8-17.4
-                0l-40.5-40.5c-4.8-4.8-4.8-12.6
-                0-17.4l67.1-66.5-67.1-66.5c-4.8-4.8-4.8-12.6
-                0-17.4l40.5-40.5c4.8-4.8 12.6-4.8 17.4 0l66.5 67.1
-                66.5-67.1c4.8-4.8 12.6-4.8 17.4 0l40.5 40.5c4.8 4.8
-                4.8 12.6 0 17.4L313.3 256l67.1 66.5z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no"></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -3200,21 +2006,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" aria-label="question mark" class="unknown" role="img">
-            <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8
-            256C8 119.083 119.043 8 256 8s248 111.083 248
-            248zM262.655 90c-54.497 0-89.255 22.957-116.549
-            63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699
-            26.31c5.205 3.947 12.621 3.008 16.665-2.122
-            17.864-22.658 30.113-35.797 57.303-35.797 20.429 0
-            45.698 13.148 45.698 32.958 0 14.976-12.363
-            22.667-32.534 33.976C247.128 238.528 216 254.941 216
-            296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373
-            12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667
-            0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46
-            20.635-46 46 0 25.364 20.635 46 46 46s46-20.636
-            46-46c0-25.365-20.635-46-46-46z"></path>
-        </svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
     </td>
     <td>The <code>video</code> element is ignored by VO unless an accessible name is provided
     </td>
@@ -3226,12 +2018,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" role="img" width="20" aria-label="none expected" class="noneE">
-            <path d="M400 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 
-            48 48h352c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zM92 
-            296c-6.6 0-12-5.4-12-12v-56c0-6.6 5.4-12 12-12h264c6.6 0 12 
-            5.4 12 12v56c0 6.6-5.4 12-12 12H92z"></path>
-        </svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -3251,5 +2038,4 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
   </div>
 </footer>
 	</div>
-
 </body></html>

--- a/VO-mac.html
+++ b/VO-mac.html
@@ -27,7 +27,7 @@ body {background-color:white}
 </style>
 </head>
 <body>
-<svg hidden>
+<svg style="display:none">
 <symbol id="yes">
     <path d="M400 480H48c-26.51 0-48-21.49-48-48V80c0-26.51
     21.49-48 48-48h352c26.51 0 48 21.49 48 48v352c0
@@ -95,7 +95,6 @@ body {background-color:white}
 <p><strong>GitHub Repo:</strong> <a href="https://github.com/TetraLogical/screen-reader-HTML-support">screen-reader-HTML-support</a>
 </p>
 <p>Found a bug? Please <a href="https://github.com/TetraLogical/screen-reader-HTML-support/issues">report it</a>. </p>
-</header>
 <main>
 <h2>How HTML elements are supported by screen readers</h2>
 <p> Typical support patterns of HTML elements by screen readers: </p>
@@ -122,14 +121,14 @@ varies from element to element and support for a particular
 element varies between screen reader software. </p>
 <h2>Support legend</h2>
 <ul>
-<li><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+<li><svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
 means we have found this feature to be implemented
 interoperably (across multiple browsers)</li>
-<li><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no"></svg> means we
+<li><svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg> means we
 have found that this feature is not implemented</li>
-<li><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+<li><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
 means the element has no expected semantics.</li>
-<li><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg> means we
+<li><svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg> means we
 are unsure whether this feature is supported, this may be due
 to lack of testing or lack of clarity around what 'support' of
 this feature is supposed to convey to the user.</li>
@@ -163,7 +162,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
 <p>VoiceOver recognizes visited/unvisited state of links.</p>
@@ -180,7 +179,7 @@ this feature is supposed to convey to the user.</li>
         <p>No special commands</p>
         </td>
         <td>
-            <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+            <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
         </td>
         <td>
         <p>Expands abbreviation if <code>title</code> attribute is present, announces as "group".</p>
@@ -195,7 +194,7 @@ this feature is supposed to convey to the user.</li>
     <td>Reads content as plain text</td>
     <td>No special commands</td>
     <td>
-    <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no"></svg>
+    <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
 
     </td>
     <td>No additional semantics conveyed</td>
@@ -214,7 +213,7 @@ this feature is supposed to convey to the user.</li>
 
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Requires alt attribute for accessibility.</td>
 </tr>
@@ -230,7 +229,7 @@ this feature is supposed to convey to the user.</li>
 
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Recognizes the start and end of articles.</td>
 </tr>
@@ -246,7 +245,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Recognized as complementary region.</td>
 </tr>
@@ -266,7 +265,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>Accessible buttons available in the player. Announcements are inconsistent across browsers.</td>
 </tr>
@@ -277,7 +276,7 @@ this feature is supposed to convey to the user.</li>
     <td>Reads content as normal text</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No specific emphasis expected.</td>
 </tr>
@@ -289,7 +288,7 @@ this feature is supposed to convey to the user.</li>
     <td>No aural interaction</td>
     <td>Not interactive</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>Typically ignored by VoiceOver.</td>
 </tr>
@@ -300,7 +299,7 @@ this feature is supposed to convey to the user.</li>
     <td>Reads content as normal text</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No aural impact; structure-only element.</td>
 </tr>
@@ -311,7 +310,7 @@ this feature is supposed to convey to the user.</li>
     <td>Reads content as normal text</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No special semantics conveyed. Reads text correctly regardless of direction.</td>
 </tr>
@@ -323,7 +322,7 @@ this feature is supposed to convey to the user.</li>
     <td>No special commands
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>No additional semantics conveyed.</td>
 </tr>
@@ -334,7 +333,7 @@ this feature is supposed to convey to the user.</li>
     <td>Reads content</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No unique aural feedback; body is implicit.</td>
 </tr>
@@ -345,7 +344,7 @@ this feature is supposed to convey to the user.</li>
     <td>No aural interaction</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No additional semantics conveyed.Treated as one new line, regardless of number of line break elements</td>
 </tr>
@@ -363,7 +362,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Recognizes the button label and, if provided, state (pressed/unpressed) when button has <code>aria-pressed</code> attribute.</td>
 </tr>
@@ -376,7 +375,7 @@ this feature is supposed to convey to the user.</li>
   <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Right/Left</kbd>  arrow to navigate, focusable via VO navigation
 </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td> 
         <ul>
@@ -404,7 +403,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>The caption linked to the table it describes</td>
 </tr>
@@ -415,7 +414,7 @@ this feature is supposed to convey to the user.</li>
     <td>Reads content as normal text</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>
     <p>No specific aural emphasis.</p>
@@ -428,7 +427,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>
         No additional semantics conveyed; read as normal text.
@@ -441,7 +440,7 @@ this feature is supposed to convey to the user.</li>
     <td>No aural indication</td>
     <td>Not directly interactive</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>Impact conveyed through table structure only.</td>
 </tr>
@@ -452,7 +451,7 @@ this feature is supposed to convey to the user.</li>
     <td>No aural indication</td>
     <td>Not directly interactive</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>Structure-enhancing, with no direct aural output.</td>
 </tr>
@@ -463,7 +462,7 @@ this feature is supposed to convey to the user.</li>
     <td><em>Element content</em></td>
     <td>No special commandss</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>Treated as regular text</td>
 </tr>
@@ -481,7 +480,7 @@ this feature is supposed to convey to the user.</li>
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         <ul>
@@ -502,7 +501,7 @@ this feature is supposed to convey to the user.</li>
 
         </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Linked with its associated <code>dt</code>, which is announced prior to the <code>dd</code> suffixed with "term" </td>
 </tr>
@@ -513,7 +512,7 @@ this feature is supposed to convey to the user.</li>
     <td>Announces "deletion" before deleted text when included as part of a tag with plain text, otherwise no aural indication</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>    
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>    
     </td>
     <td>
 Support is inconsistent across browsers and "deletion" is only ever announced when part of a tag with plain text
@@ -533,7 +532,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Recognizes expanded/collapsed state.</td>
 </tr>
@@ -544,7 +543,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No additional semantics conveyed</td>
 </tr>
@@ -554,11 +553,11 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td>Modal dialog</td>
     <td><ul>
         <li>On button that invokes a dialog: announces as label + "button", or "dialog pop-up, button" if element has an <code>aria-haspopup="dialog"</code> attribute</li>
-        <li>On dialog: announces "dialog" on Chrome or "web dialog" on Safari, followed by the auto focused control on dialog</td></li>
-    </ul>
+        <li>On dialog: announces "dialog" on Chrome or "web dialog" on Safari, followed by the auto focused control on dialog</li>
+    </ul></td>
     <td>Focus moved to dialog when opened</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Recognizes and traps focus within modal dialog</td>
 </tr>
@@ -569,7 +568,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No semantics conveyed unless ARIA roles are provided</td>
 </tr>
@@ -586,7 +585,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Identifies number of items within the <code>dl</code> list</td>
 </tr>
@@ -606,7 +605,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         Part of list navigation
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Associated with the following <code>dd</code></td>
 </tr>
@@ -617,7 +616,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td>Element content</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>
         No semantics conveyed. Refer to: <a href="https://www.tpgi.com/screen-readers-support-for-text-level-html-semantics/">Screen 
@@ -640,7 +639,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
        
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>    
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>    
     </td>
     <td>
         <ul>
@@ -664,7 +663,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Only when <code>fieldset</code> has an accessible name via <code>legend</code> or other method</td>
 </tr>
@@ -675,7 +674,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Announces when associated with a figure.</td>
 </tr>
@@ -696,7 +695,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
     <ul>
@@ -717,7 +716,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         <ul>
@@ -744,7 +743,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -757,7 +756,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
        <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Command</kbd> + <kbd>H</kbd> to navigate to next heading
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Identifies heading level and text</td>
 </tr>
@@ -768,7 +767,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -784,7 +783,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>  
          <ul>
@@ -804,7 +803,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Properly indicates a thematic break</td>
 </tr>
@@ -815,7 +814,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No semantics expected.</td>
 </tr>
@@ -826,7 +825,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No semantics conveyed.</td>
 </tr>
@@ -853,7 +852,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Recognizes frame title when present</td>
 </tr>
@@ -875,7 +874,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Reads alt attribute content if present.</td>
 </tr>
@@ -888,7 +887,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Space</kbd>  to activate
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Recognizes button type and label</td>
 </tr>
@@ -901,7 +900,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Space</kbd>  to check/uncheck
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Identifies the label and state</td>
 </tr>
@@ -914,7 +913,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Space</kbd>  to open colour picker
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Allows selection of colours from the palette</td>
 </tr>
@@ -927,7 +926,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Shift</kbd> + <kbd>Down</kbd> Arrow to edit date area, + <kbd>Right/Left</kbd> Arrows to navigate between date fields and <kbd>Up/Down</kbd> arrows to adjust stepper
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         
@@ -943,7 +942,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
 
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>Treated as a regular text field</td>
 </tr>
@@ -956,7 +955,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
 	    <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Space</kbd>  to open file selection control
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         <ul>
@@ -972,7 +971,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Used for form data; ignored by VoiceOver</td>
 </tr>
@@ -988,7 +987,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Space</kbd>  to activate
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>In Chrome, announces "edit text" when input is focused</td>
 </tr>
@@ -1004,7 +1003,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Editable text field when focused with VO or the incremental stepper can be interacted with by use of <kbd>Up/Down</kbd> arrow keys</td>
 </tr>
@@ -1018,7 +1017,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
 
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         <ul>
@@ -1038,7 +1037,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Space</kbd>  to select radio button
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Recognizes position within radio group</td>
 </tr>
@@ -1054,7 +1053,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         <p>Allows setting a value within a defined range. Slider value announced as it changes.</p>
@@ -1069,7 +1068,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Space</kbd>  to activate
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Resets all form inputs to their default values</td>
 </tr>
@@ -1087,7 +1086,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
 
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No special commands</td>
 </tr>
@@ -1100,7 +1099,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Space</kbd>  to activate
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Submits the form data to the server</td>
 </tr>
@@ -1114,7 +1113,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
 
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Announces "edit text" when input is focused</td>
 </tr>
@@ -1137,7 +1136,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
 
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Announces "edit text" when input is focused</td>
 </tr>
@@ -1148,7 +1147,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td>Announces current time value + "time area"</td>
       <td><kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Shift</kbd> + <kbd>Down</kbd> Arrow to edit time values, <kbd>Up/Down</kbd> Arrow keys to increase/decrease stepper value/td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Provides an hour/minute input interface.</td>
 </tr>
@@ -1162,7 +1161,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
 
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Announces "edit text" when input is focused</td>
 </tr>
@@ -1173,7 +1172,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td>Announces "insertion" before inserted text when included as part of a tag with plain text, otherwise no aural indication</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>
         Support was inconsistent across browsers and "insertion" is only ever announced when part of a tag with plain text 
@@ -1186,7 +1185,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td>Reads content as plain text</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -1201,7 +1200,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>No semantics beyond association with input conveyed</td>
 </tr>
@@ -1214,7 +1213,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td>Legend content is announced as the group label for a group of related controls when one of the controls is first focused in the group.</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Serves as the group label for a group of form controls. Refer to the <a href="#toc-f">fieldset</a> element</td>
 </tr>
@@ -1237,7 +1236,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
        <kbd>Control</kbd> + <kbd>Option</kbd> + Right Arrow to navigate
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Announces total item count and position of list items within list</td>
 </tr>
@@ -1247,7 +1246,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td>Link metadata</td>
     <td><em>None expected</em></td>
     <td>No special commands</td>
-    <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg></td>
+    <td><svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg></td>
     <td>No UI</td>
 </tr>
 <tr id="toc-m" tabindex="-1">
@@ -1262,7 +1261,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>Identified as a main landmark region</td>
 </tr>
@@ -1273,7 +1272,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -1286,7 +1285,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     </td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>If an <code>aria-label</code> is provided then VO recognises the start and end of highlighted content</td>
 </tr>
@@ -1297,7 +1296,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -1308,7 +1307,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td>Announces as current value + fallback content/accessible name + "level indicator" </td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>
         <ul>
@@ -1335,7 +1334,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Identified as a navigation landmark</td>
 </tr>
@@ -1346,7 +1345,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td>Content of <code>&lt;noscript&gt;</code> element read if JavaScript is not available/enabled</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>Ignored when JavaScript is enabled.</td>
 </tr>
@@ -1364,7 +1363,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>
         <ul>
@@ -1386,7 +1385,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Announces list structure and number of items</td>
 </tr>
@@ -1397,7 +1396,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td>No aural indication</td>
     <td><kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Space</kbd>  to expand/collapse options list box</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>
         When <code>optgroup</code> element is labelled by an <code>aria-label</code>/<code>aria-labelledby</code> the label content is announced as "dimmed"
@@ -1410,7 +1409,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td>Announced as option content + checkmark if currently selected</td>
     <td><kbd>Up/Down</kbd> arrow keys to navigate options</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Use <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Space</kbd>  to expand/collapse options list</td>
 </tr>
@@ -1426,7 +1425,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     </td>
     <td>No special commands</td>
     <td>
-        <svg\s+viewBox="0\s+0\s+512\s+512"\s+width="20"\s+aria-label="question\s+mark"\s+class="unknown"\s+role="img">\s+<path\s+d="M504\s+256c0\s+136\.997-111\.043\s+248-248\s+248S8\s+392\.997\s+8\s+256C8\s+119\.083\s+119\.043\s+8\s+256\s+8s248\s+111\.083\s+248\s+248zM262\.655\s+90c-54\.497\s+0-89\.255\s+22\.957-116\.549\s+63\.758-3\.536\s+5\.286-2\.353\s+12\.415\s+2\.715\s+16\.258l34\.699\s+26\.31c5\.205\s+3\.947\s+12\.621\s+3\.008\s+16\.665-2\.122\s+17\.864-22\.658\s+30\.113-35\.797\s+57\.303-35\.797\s+20\.429\s+0\s+45\.698\s+13\.148\s+45\.698\s+32\.958\s+0\s+14\.976-12\.363\s+22\.667-32\.534\s+33\.976C247\.128\s+238\.528\s+216\s+254\.941\s+216\s+296v4c0\s+6\.627\s+5\.373\s+12\s+12\s+12h56c6\.627\s+0\s+12-5\.373\s+12-12v-1\.333c0-28\.462\s+83\.186-29\.647\s+83\.186-106\.667\s+0-58\.002-60\.165-102-116\.531-102zM256\s+338c-25\.365\s+0-46\s+20\.635-46\s+46\s+0\s+25\.364\s+20\.635\s+46\s+46\s+46s46-20\.636\s+46-46c0-25\.365-20\.635-46-46-46z"><\/path>\s+<\/svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>VO only recognises the element as "output/status" if the <code>output</code> element has an accessible name. Otherwise, the semantics are ignored and only the value is announced.</td>
 </tr>
@@ -1439,7 +1438,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>P</kbd> to read paragraph
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>No aural semantics.</td>
 </tr>
@@ -1450,7 +1449,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -1461,7 +1460,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -1472,7 +1471,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-       <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+       <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -1483,7 +1482,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td>Announced as accessible name (if present) + current percentage value + "progress indicator"
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         VO does not announce the new value of the progress bar if the <code>value</code> attribute is updated
@@ -1496,7 +1495,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>
         <ul>
@@ -1512,7 +1511,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -1523,7 +1522,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -1534,7 +1533,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -1545,7 +1544,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -1556,7 +1555,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -1567,7 +1566,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -1578,7 +1577,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>     
         <ul>
@@ -1594,7 +1593,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -1617,7 +1616,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>No semantics conveyed unless the section has an accessible name, in which case VO treats the it as a landmark region.</td>
 </tr>
@@ -1640,7 +1639,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Provides list of options</td>
 </tr>
@@ -1651,7 +1650,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -1665,7 +1664,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -1676,7 +1675,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -1687,7 +1686,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>  
         <ul>
@@ -1703,7 +1702,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -1714,7 +1713,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>   
         <ul>
@@ -1744,7 +1743,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Serves as a trigger for expanding/collapsing <code>&lt;details&gt;</code> section.</td>
 </tr>
@@ -1755,7 +1754,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>
         <ul>
@@ -1781,7 +1780,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>In Safari, the standard keyboard shortcut <kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>Command</kbd> + <kbd>G</kbd> navigates to individual polygon elements within the <code>&lt;svg&gt;</code></td>
 </tr>
@@ -1805,7 +1804,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>
         <ul>
@@ -1822,7 +1821,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -1838,7 +1837,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Announces corresponding header if programmatically associated.</td>
 </tr>
@@ -1849,7 +1848,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>
@@ -1867,7 +1866,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Announces "edit text" when input is focused</td>
 </tr>
@@ -1881,7 +1880,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-         <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no"></svg>
+         <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -1892,7 +1891,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special command. Reachable using standard table cell reading keystrokes.</td>
     <td>
-         <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no"></svg>
+         <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -1903,7 +1902,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-         <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no"></svg>
+         <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -1914,7 +1913,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td>Announced as <em>element content</em>, or in Safari, accessible name + <em>element content</em> + "group", if element has an accessible name through an <code>aria-label/aria-labelledby</code> attribute</td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>In Safari, content in <code>time</code> element is repeated twice</td>
 </tr>
@@ -1930,7 +1929,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
         
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -1941,7 +1940,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td><kbd>Control</kbd> + <kbd>Option</kbd> + <kbd>R</kbd> to read all cell content in current row</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -1952,7 +1951,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Caption display control</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -1963,7 +1962,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>Element content</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -1979,7 +1978,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul>
     </td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="yes" class="yes"><use href="#yes" /></svg>
     </td>
     <td>Announces list structure and number of items</td>
 </tr>
@@ -1991,7 +1990,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     </td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="no" class="no"><use href="#no" /></svg>
     </td>
     <td>No semantics conveyed</td>
 </tr>
@@ -2006,7 +2005,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
         </ul></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown"></svg>
+        <svg viewBox="0 0 512 512" width="20" role="img" aria-label="question mark" class="unknown"><use href="#unknown" /></svg>
     </td>
     <td>The <code>video</code> element is ignored by VO unless an accessible name is provided
     </td>
@@ -2018,7 +2017,7 @@ Support is inconsistent across browsers and "deletion" is only ever announced wh
     <td><em>None expected</em></td>
     <td>No special commands</td>
     <td>
-        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE"></svg>
+        <svg viewBox="0 0 448 512" width="20" role="img" aria-label="none expected" class="noneE"><use href="#noneE" /></svg>
     </td>
     <td>No UI</td>
 </tr>


### PR DESCRIPTION
Instead of repeating the same paths in the SVG icons, have each path once in the page in a `<symbol>` that's referenced using `<use …/>` elements. This significantly reduces the size of the pages.

Includes some fixes including an unclosed `<svg>`, misplaced `</td>`, extra `</header>` and SVG icons without `role="img"`.