### PR TITLE
Updates screen reader HTML support table for JAWS for all elements beginning with "a"

### DIFF
--- a/JAWS.html
+++ b/JAWS.html
@@ -488,7 +488,7 @@
                     Test A-006: anchor with an <code>href</code> attribute, with visible text, <code>title</code>, and <code>aria-label</code> attributes that all have the same values
                   </a>:
                   <ul>
-                    <li><kbd>Tab</kbd> key navigation:<br> <em>visible link text</em>, link, <em><code>title</code> text</em>, to activate press Enter</li>
+                    <li><kbd>Tab</kbd> key navigation:<br> <em>visible link text</em>, link, to activate press Enter</li>
                     <li><kbd>Arrow</kbd> key navigation:<br> [Visited] link, <em>visible link text</em></li>
                   </ul>
                 </li>
@@ -526,16 +526,26 @@
             <td>
               <p> <strong>With <code>href</code>:</strong> </p>
               <ul>
-                <li>The link role is announced <em>before</em> the link label when using reading keys like
+                <li>In all cases, JAWS announces the link role</li>
+                <li>In all cases, JAWS announces the link role <em>before</em> the link label when using reading keys like
                   the <kbd>Arrow</kbd> keys, but <em>after</em> the link label when using the <kbd>Tab</kbd> key</li>
-                <li>JAWS announces instructions for activating the link when the link receives focus via the
+                <li>In all cases, JAWS announces instructions for activating the link when the link receives focus via the
                   <kbd>Tab</kbd> key, but not when the link receives focus via the <kbd>Arrow</kbd> keys
                 </li>
                 <li>When a link has both visible text and a <code>title</code>
-                attribute (but no other attributes), JAWS announces both together</li>
-                <li>JAWS announces the value of the <code>aria-label</code> attribute when it is
-                applied to the <code>&lt;a&gt;</code> element, not the visible text, which is as expected</li>
-                <li>IN PROGRESS</li>
+                attribute (but no other attributes), JAWS announces the contents of both together</li>
+                <li>JAWS announces the contents of the <code>aria-label</code> attribute when it is
+                applied to the <code>&lt;a&gt;</code> element, not the visible text</li>
+                <li>JAWS announces the content referenced using the <code>aria-describedby</code> 
+                attribute when the link receives focus via the <kbd>Tab</kbd> key, but not when
+                the link receives focus via the <kbd>Arrow</kbd> keys</li>
+                <li>When a link has different visible text, <code>title</code> text, <code>aria-label</code>
+                text, and content referenced via the <code>aria-describedby</code> attribute, JAWS only
+                announces the content of the <code>aria-label</code> attribute and the content referenced
+                using the <code>aria-describedby</code> attribute; the visible text is not announced,
+                nor is the content within the <code>title</code> attribute</li>
+                <li>When a link has the same visible text, <code>title</code> text, and
+                <code>aria-label</code> text, JAWS only announces the visible link text</li>
               </ul>
               <br>
               <p> <strong>Link types:</strong> </p>      
@@ -558,7 +568,7 @@
               </ul>
               <br>
 
-              <p><strong>Additional notes [TO BE CHECKED]:</strong></p>
+              <p><strong>Additional notes:</strong></p>
 
               <ul>
                 <li>The following from the JAWS help documentation does not appear to work and is not required:

--- a/JAWS.html
+++ b/JAWS.html
@@ -228,7 +228,7 @@
     <h1>JAWS HTML Support</h1>
     <dl>
       <dt>A Work <em>in progress</em>:</dt>
-      <dd>Last updated 3 February 2026. </dd>
+      <dd>Last updated 7 May 2026. </dd>
       <dt>Editor:</dt>
       <dd>Steve Faulkner</dd>
       <dt>GitHub Repo:</dt>

--- a/JAWS.html
+++ b/JAWS.html
@@ -1398,7 +1398,7 @@
                       <kbd>Tab</kbd> key navigation:
                       <p>One of the following (refer to notes):</p>
                       <ol>
-                        <li>Elapsed time, colon zero colon zero zero one zero zero, mute, group; <strong>or</strong></strong></li>
+                        <li>Elapsed time, colon zero colon zero zero one zero zero, mute, group; <strong>or</strong></li>
                         <li><em>contents of the <code>aria-label</code> attribute</em>, group</li>
                       </ol>
                     </li>
@@ -1415,7 +1415,7 @@
                       <kbd>Tab</kbd> key navigation:
                       <p>One of the following (refer to notes):</p>
                       <ol>
-                        <li>Elapsed time, colon zero colon zero zero one zero zero, mute, group; <strong>or</strong></strong></li>
+                        <li>Elapsed time, colon zero colon zero zero one zero zero, mute, group; <strong>or</strong></li>
                         <li><em>contents of the <code>aria-label</code> attribute</em>, group</li>
                       </ol>
                     </li>

--- a/JAWS.html
+++ b/JAWS.html
@@ -558,10 +558,10 @@
               </ul>
               <br>
 
-              <p><strong>Additional notes:</strong></p>
+              <p><strong>Additional notes [TO BE CHECKED]:</strong></p>
 
               <ul>
-                <li>[TO BE CHECKED] The following from the JAWS help documentation does not appear to work and is not required:
+                <li>The following from the JAWS help documentation does not appear to work and is not required:
                 "By Default, JAWS speaks the on screen text of a
                   link, but you can set JAWS to instead speak Title
                   text, assigned by the page author within the HTML

--- a/JAWS.html
+++ b/JAWS.html
@@ -231,6 +231,8 @@
       <dd>Last updated 7 May 2026. </dd>
       <dt>Editor:</dt>
       <dd>Steve Faulkner</dd>
+      <dt>Co-editor:</dt>
+      <dd>Graeme Coleman</dd>
       <dt>GitHub Repo:</dt>
       <dd><a href="https://github.com/TetraLogical/screen-reader-HTML-support">screen-reader-HTML-support</a></dd>
       <dt>Found a bug?</dt>
@@ -434,10 +436,64 @@
               <p>&nbsp;</p>
             </td>
             <td>
-              <p> <strong>With <code>href</code>:</strong> <em>element
+              <p> <strong>With <code>href</code>:</strong></p>
+              <ul>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/a-href.html#a-001">
+                    Test A-001: anchor with <code>href</code>
+                  </a>:
+                  <ul>
+                    <li><kbd>Tab</kbd> key navigation:<br> <em>visible link text</em>, link, to activate press Enter</li>
+                    <li><kbd>Arrow</kbd> key navigation:<br> [Visited] link, <em>visible link text</em></li>
+                  </ul>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/a-href.html#a-002">
+                    Test A-002: anchor with <code>href</code> & <code>title</code> attribute
+                  </a>:
+                  <ul>
+                    <li><kbd>Tab</kbd> key navigation:<br> <em>visible link text</em>, link, <em><code>title</code> text</em>, to activate press Enter</li>
+                    <li><kbd>Arrow</kbd> key navigation:<br> [Visited] link, <em>visible link text</em>, <em><code>title</code> text</em></li>
+                  </ul>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/a-href.html#a-003">
+                    Test A-003: anchor with <code>href</code> and <code>aria-label</code> attribute
+                  </a>:
+                  <ul>
+                    <li><kbd>Tab</kbd> key navigation:<br> <em>aria-label text</em>, link, to activate press Enter</li>
+                    <li><kbd>Arrow</kbd> key navigation:<br> [Visited] link, <em>aria-label text</em></li>
+                  </ul>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/a-href.html#a-004">
+                    Test A-004: anchor with <code>href</code>, <code>aria-label</code> and <code>aria-describedby</code> attributes
+                  </a>:
+                  <ul>
+                    <li><kbd>Tab</kbd> key navigation:<br> <em>aria-label text</em>, link, <em>text referenced by the <code>aria-describedby</code> attribute</em>, to activate press Enter</li>
+                    <li><kbd>Arrow</kbd> key navigation:<br> [Visited] link, <em>aria-label text</em></li>
+                  </ul>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/a-href.html#a-005">
+                    Test A-005: anchor with visible text, <code>href</code>, <code>title</code>, <code>aria-label</code> and <code>aria-describedby</code> attributes
+                  </a>:
+                  <ul>
+                    <li><kbd>Tab</kbd> key navigation:<br> <em>aria-label text</em>, link, <em>text referenced by the <code>aria-describedby</code> attribute</em>, to activate press Enter</li>
+                    <li><kbd>Arrow</kbd> key navigation:<br> [Visited] link, <em>aria-label text</em></li>
+                  </ul>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/a-href.html#a-006">
+                    Test A-006: anchor with an <code>href</code> attribute, with visible text, <code>title</code>, and <code>aria-label</code> attributes that all have the same values
+                  </a>:
+                  <ul>
+                    <li><kbd>Tab</kbd> key navigation:<br> <em>visible link text</em>, link, <em><code>title</code> text</em>, to activate press Enter</li>
+                    <li><kbd>Arrow</kbd> key navigation:<br> [Visited] link, <em>visible link text</em></li>
+                  </ul>
+                </li>
+              </ul>
 
-
-                  content</em> "link" </p>
               <p>&nbsp;</p>
             </td>
             <td>
@@ -469,21 +525,21 @@
             </td>
             <td>
               <p> <strong>With <code>href</code>:</strong> </p>
-              <p>Link role announced before link text when cursored to,
-                after via tab. </p>
               <ul>
-                <li><b>Note:</b> the following from the JAWS help documentation does not appear to work and is not required:
-                "By Default, JAWS speaks the on screen text of a
-                  link, but you can set JAWS to instead speak Title
-                  text, assigned by the page author within the HTML
-                  code. Title text normally provides supplemental
-                  information about the link".</li>
-                <li>By default, JAWS announces the link type, but you
-                  can disable this, so JAWS announces same page links,
-                  send mail links, and FTP links as "link," or "Visited
-                  Link."</li>
+                <li>The link role is announced <em>before</em> the link label when using reading keys like
+                  the <kbd>Arrow</kbd> keys, but <em>after</em> the link label when using the <kbd>Tab</kbd> key</li>
+                <li>JAWS announces instructions for activating the link when the link receives focus via the
+                  <kbd>Tab</kbd> key, but not when the link receives focus via the <kbd>Arrow</kbd> keys
+                </li>
+                <li>When a link has both visible text and a <code>title</code>
+                attribute (but no other attributes), JAWS announces both together</li>
+                <li>JAWS announces the value of the <code>aria-label</code> attribute when it is
+                applied to the <code>&lt;a&gt;</code> element, not the visible text, which is as expected</li>
+                <li>IN PROGRESS</li>
               </ul>
-              <p>JAWS announces the type of link as follows:</p>
+              <br>
+              <p> <strong>Link types:</strong> </p>      
+
               <ul>
                 <li><strong>Link:</strong> This indicates a link that
                   has not been visited.</li>
@@ -500,6 +556,24 @@
                 <li><strong>FTP Link:</strong> This indicates a link
                   that points to a FTP (File Transfer Protocol) server.</li>
               </ul>
+              <br>
+
+              <p><strong>Additional notes:</strong></p>
+
+              <ul>
+                <li>[TO BE CHECKED] The following from the JAWS help documentation does not appear to work and is not required:
+                "By Default, JAWS speaks the on screen text of a
+                  link, but you can set JAWS to instead speak Title
+                  text, assigned by the page author within the HTML
+                  code. Title text normally provides supplemental
+                  information about the link".</li>
+                <li>By default, JAWS announces the link type, but you
+                  can disable this, so JAWS announces same page links,
+                  send mail links, and FTP links as "link," or "Visited
+                  Link."</li>
+              </ul>
+             
+              
               <p>&nbsp;</p>
               <p>&nbsp;</p>
             </td>

--- a/JAWS.html
+++ b/JAWS.html
@@ -225,7 +225,7 @@
   </header>
   <div class="region wrapper prose flow">
 
-    <h1>JAWS HTML Support</h1>
+    <h1>JAWS HTML Support test</h1>
     <dl>
       <dt>A Work <em>in progress</em>:</dt>
       <dd>Last updated 3 February 2026. </dd>

--- a/JAWS.html
+++ b/JAWS.html
@@ -594,7 +594,27 @@
             <td><a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/a-no-href.html"><code>a</code> with
                 no <code>href</code> test</a></td>
             <td>An anchor</td>
-            <td>Announces as plain text</td>
+            <td>
+               <ul>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/a-no-href.html#a-001">
+                    Test A-001: anchor with no <code>href</code></a>: <em>visible text</em>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/a-no-href.html#a-002">
+                    Test A-002: anchor with no <code>href</code> and with <code>aria-label</code> attribute</a>: <em>visible text</em>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/a-no-href.html#a-003">
+                    Test A-003: anchor with no <code>href</code> and with no accessible name</a>: anchor is skipped altogether
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/a-no-href.html#a-004">
+                    Test A-004: anchor with no <code>href</code> and <code>tabindex="0"</code></a>: <em>visible text</em>
+                </li>
+              </ul>
+
+            </td>
             <td>No special commands</td>
             <td><svg viewBox="0 0 448 512"
                    width="20"
@@ -614,14 +634,81 @@
             <td><a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/abbr.html"><code>abbr</code>
                 test</a></td>
             <td>An abbreviation</td>
-            <td><em>Element content</em></td>
+            <td>
+              <ul>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/abbr.html#abb-001">
+                    Test ABB-001: <code>abbr</code> element with <code>title</code> attribute</a>: 
+                  <ul>
+                    <li>By default: <em>visible text</em>, <em>title text</em></li>
+                    <li>Via preference: <em>title text</em></li>
+                  </ul>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/abbr.html#abb-002">
+                    Test ABB-002: <code>abbr</code> element without <code>title</code> attribute</a>:
+                  <ul>
+                    <li>By default: <em>visible text</em></li>
+                    <li>Via preference: <em>visible text</em></li>
+                  </ul>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/abbr.html#abb-003">
+                    Test ABB-003: <code>abbr</code> element with <code>aria-label</code> attribute</a>:
+                  <ul>
+                    <li>By default: <em>visible text</em></li>
+                    <li>Via preference: <em>visible text</em></li>
+                  </ul>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/abbr.html#abb-004">
+                    Test ABB-004: <code>abbr</code> element with <code>aria-label</code> attribute and <code>aria-describedby</code> attribute</a>:
+                  <ul>
+                    <li>By default: <em>visible text</em></li>
+                    <li>Via preference: <em>visible text</em></li>
+                  </ul>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/abbr.html#abb-005">
+                    Test ABB-005: <code>abbr</code> element with <code>aria-label</code> and <code>title</code> attributes</a>:
+                  <ul>
+                    <li>By default: <em>visible text</em>, <em>title text</em></li>
+                    <li>Via preference: <em>title text</em></li>
+                  </ul>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/abbr.html#abb-006">
+                    Test ABB-006: <code>abbr</code> element with <code>aria-label</code> and <code>title</code> attributes</a> with differing values:
+                  <ul>
+                    <li>By default: <em>visible text</em>, <em>title text</em></li>
+                    <li>Via preference: <em>title text</em></li>
+                  </ul>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/abbr.html#abb-007">
+                    Test ABB-007: <code>abbr</code> element with <code>title</code> and <code>tabindex="0"</code> attributes</a>:
+                  <ul>
+                    <li>By default: <em>visible text</em>, <em>title text</em></li>
+                    <li>Via preference: <em>title text</em></li>
+                  </ul>
+                </li>
+              </ul>
+            </td>
             <td>
               <p>No special commands</p>
+              <p>&nbsp;</p>
               <p>JAWS can read <code>title</code> text associated with
-                abbreviations on web pages. <br>
-                To enable this feature, open Settings Center and expand
-                the Web/HTML/PDFs group. Next, expand the Reading group
-                and use the abbreviation and acronym options</p>
+                abbreviations and acronyms on web pages.<br>To enable this feature:</p>
+                <ol>
+                  <li>Open the <strong>Utilities</strong> menu</li>
+                  <li>Select <strong>Settings Center</strong></li>
+                  <li>Expand the <strong>Web/HTML/PDFs</strong> group</li>
+                  <li>Expand the <strong>Reading</strong> group</li>
+                  <li>Navigate to the Expand Abbreviations option and press <kbd>Space</kbd>
+                  to check its checkbox</li>
+                  <li>Navigate to the Expand Acronyms option and press <kbd>Space</kbd>
+                  to check its checkbox</li>
+                </ol>
             </td>
             <td>
               <p>By default
@@ -645,13 +732,11 @@
             </td>
             <td>
               <p>No semantics conveyed by default</p>
+              <p>&nbsp;</p>
               <p>Note that expansions are not announced by default and
                 that expansions provided using the <code>title</code> attribute are not available to keyboard only
                 users.
-                Refer to <a href="https://www.paciellogroup.com/blog/2013/01/using-the-html-title-attribute-updated/">Using
-
-
-                  the HTML title attribute</a>.</p>
+                Refer to <a href="https://www.paciellogroup.com/blog/2013/01/using-the-html-title-attribute-updated/">Using the HTML title attribute</a>.</p>
             </td>
           </tr>
           <tr>
@@ -660,8 +745,28 @@
             <td><a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/address.html"><code>address</code>
                 test</a></td>
             <td>Contact information for a page or <a href="https://html.spec.whatwg.org/multipage/sections.html#the-article-element">article</a> element</td>
-            <td><em>Element content</em> when no accessible name
-              present. </td>
+            <td>
+              <ul>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/address.html#add-001">
+                    Test ADD-001: <code>address</code> element</a>: <em>visible text</em>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/address.html#add-002">
+                    Test ADD-002: <code>address</code> element with <code>aria-label</code></a>: <strong>Group start</strong> <em>aria-label text</em>, <em>visible text</em>, <strong>Group end</strong> <em>aria-label text</em> 
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/address.html#add-003">
+                    Test ADD-003: <code>address</code> element with <code>aria-label</code> and <code>aria-describedby</code></a>: <strong>Group start</strong> <em>aria-label text</em>, <em>visible text</em>, <strong>Group end</strong> <em>aria-label text</em> 
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/address.html#add-004">
+                    Test ADD-004: <code>address</code> element with <code>tabindex="0"</code></a>: <em>visible text</em>
+                </li>
+              </ul>
+
+
+            </td>
             <td>No special commands</td>
             <td>
               <p>no accessible name
@@ -683,9 +788,14 @@
                 </svg>
               </p>
             </td>
-            <td>With accessible name <code>address</code> is announced
-              as a <code>group</code> Group - accessible name,
-              start/end.</td>
+            <td>
+              With an explicit accessible name provided using (for example) the
+              <code>aria-label</code> attribute, <code>address</code> is
+              announced as a <code>group</code>.
+              <p>&nbsp;</p>
+              Without an explicit accessible name provided using (for example) the
+              <code>aria-label</code> attribute, the <code>group</code> role
+              is not announced, nor is any other role.
           </tr>
           <tr>
             <th scope="row"> <a href="https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element"><code>area</code></a>
@@ -694,10 +804,48 @@
                 test</a></td>
             <td>Hyperlink or dead area on an image map</td>
             <td>
-              <p>"graphic"<em>, alt content </em>(when navigated using
-                the <kbd>arrow</kbd> keys or the link navigation keys.)</p>
-              <p><em>alt content</em>, "image map" (when navigated using
-                the <code>tab</code> key.</p>
+              <ul>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/area.html#area-001">
+                    Test AREA-001: <code>area</code> element</a>:
+                  <ul>
+                    <li>
+                      <kbd>Tab</kbd> key navigation:
+                      <ul>
+                        <li>When navigating into the map from above / below: <em>contents of the <code>alt</code> attribute on the <code>&lt;img&gt;</code> element</em>, image map, <em>contents of the <code>alt</code> attribute on the <code>&lt;area&gt;</code> element</em>, image map, link, graphic, to activate press Enter</li>
+                        <li>When navigating to individual items within the map: <em>contents of the <code>alt</code> attribute on the <code>&lt;area&gt;</code> element</em>, image map, link, graphic, to activate press Enter</li>
+                      </ul>
+                    </li>
+                    <li>
+                      <kbd>Arrow</kbd> key navigation:
+                      <ul>
+                        <li>When navigating into the map from above / below: Image map, link, graphic, <em>contents of the <code>alt</code> attribute on the <code>&lt;area&gt;</code> element</em></li>
+                        <li>When navigating to individual items within the map: Image map, link, graphic, <em>contents of the <code>alt</code> attribute on the <code>&lt;area&gt;</code> element</em></li>
+                      </ul>
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/area.html#area-002">
+                    Test AREA-002: <code>area</code> element with <code>aria-label</code> instead of <code>alt</code></a>:
+                  <ul>
+                    <li>
+                      <kbd>Tab</kbd> key navigation:
+                      <ul>
+                        <li>When navigating into the map from above / below: <em>contents of the <code>alt</code> attribute on the <code>&lt;img&gt;</code> element</em>, image map, <em>contents of the <code>aria-label</code> attribute on the <code>&lt;area&gt;</code> element</em>, image map, link, graphic, to activate press Enter</li>
+                        <li>When navigating to individual items within the map: <em>contents of the <code>aria-label</code> attribute on the <code>&lt;area&gt;</code> element</em>, image map, link, graphic, to activate press Enter</li>
+                      </ul>
+                    </li>
+                    <li>
+                      <kbd>Arrow</kbd> key navigation:
+                      <ul>
+                        <li>When navigating into the map from above / below: Image map, link, graphic, <em>contents of the <code>aria-label</code> attribute on the <code>&lt;area&gt;</code> element</em></li>
+                        <li>When navigating to non-start / non-end squares within the map: Image map, link, graphic, <em>contents of the <code>aria-label</code> attribute on the <code>&lt;area&gt;</code> element</em></li>
+                      </ul>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
             </td>
             <td>
               <ul>
@@ -721,17 +869,104 @@
               </svg>
               <br>
             </td>
-            <td>Although area elements are links they are not conveyed
-              as links aurally.</td>
+            <td>
+              <p>When navigating into the image map for the first time using the <kbd>Tab</kbd> key,
+              JAWS announces the contents of the <code>alt</code> attribute applied to the associated
+              <code>&lt;img&gt;</code> element. However, it does not announce the contents of this
+              <code>alt</code> attribute when navigating into the image map using the <kbd>Arrow</kbd>
+              keys.</p>
+              <p>&nbsp;</p>
+              <p>When navigating into the image map for the first time using the <kbd>Tab</kbd> key,
+              JAWS announces the term <em>image map</em> twice: the first time in relation to the
+              associated <code>&lt;img&gt;</code> element, and a second time in relation to the associated
+              <code>&lt;map&gt;</code> element. However, it only announces the term <em>image map</em>
+              once when navigating into the map using the <kbd>Arrow</kbd> keys.</p>
+              <p>&nbsp;</p>
+              <p>When navigating through individual images in the map using the <kbd>Tab</kbd> key, 
+              JAWS announces the contents of the <code>alt</code> or <code>aria-label</code> attribute on
+              the <code>&lt;area&gt;</code> element first, and then announces the element's role and
+              instructions. When navigating through individual images in the map using the <kbd>Arrow</kbd>
+              keys, JAWS announces the contents of the element's role and instructions first, and then
+              announces the contents of the <code>alt</code> or <code>aria-label</code> attribute on
+              the <code>&lt;area&gt;</code> element.</p>
+              <p>&nbsp;</p>
+              <p>From an aural point of view, there is no difference to using the <code>aria-label</code>
+              attribute as opposed to the <code>alt</code> attribute on the <code>&lt;area&gt;</code> element.
+              JAWS announces both in the same way.</p>
+            </td>
           </tr>
           <tr>
             <th scope="row"> <a href="https://www.w3.org/TR/wai-aria-1.3/#aria-level"><code>aria-level</code></a> </th>
-            <td><a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/h7-h10.html">h7-h10
-                (role="heading"+aria-level=7-10)</a></td>
+            <td>
+              <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/h7-h10.html"><code>h7</code>-<code>h9</code> via <code>aria-level</code> elements</a>
+            </td>
             <td>heading levels greater than 6 </td>
-            <td>not supported, all <code>aria-level</code> reported as <code>h2</code><br></td>
             <td>
               <ul>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/h7-h10.html#hd-001">
+                    Test HD-001: <code>h7</code>-<code>h9 elements</code> element</a>:
+                    <p>
+                      <strong>Not supported:</strong> all <code>aria-level</code> examples reported as <code>h2</code>,
+                       except for <code>&lt;h4 id="hd-04" aria-level="10"&gt;</code> which is reported as <code>h4</code>. 
+                    </p>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/h7-h10.html#hd-002">
+                    Test HD-002: <code>h1</code> element, with <code>role="heading"</code> &amp; <code>aria-level="7"</code></a>: <em>TO DO</em>
+                    <p>
+                      <strong>Not supported:</strong> the <code>aria-level</code> example is reported as <code>h2</code>.
+                    </p>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/h7-h10.html#hd-003">
+                    Test HD-003: <code>h2</code> element, with <code>aria-level="8"</code></a>:
+                    <p>
+                      <strong>Not supported:</strong> the <code>aria-level</code> example is reported as <code>h2</code>.
+                    </p>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/h7-h10.html#hd-004">
+                    Test HD-004: <code>h1</code>-<code>h6</code> + <code>aria-level</code> 7-12 elements with no content</a>:
+                    <p>
+                      <strong>Not applicable:</strong> there is no example to test
+                    </p>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/h7-h10.html#hd-005">
+                    Test HD-005: <code>h7</code>-<code>h12</code> (<code>aria-level</code> 7-12) elements with <code>aria-label</code></a>:
+                    <p>
+                      <strong>Not supported:</strong> all <code>aria-level</code> examples reported as <code>h2</code>,
+                       except for:
+                    </p>
+                    <ul>
+                      <li><code>&lt;h4 id="hda-040" aria-label="Belton" aria-level="10"&gt;</code> which is reported as <code>h4</code></li>
+                      <li><code>&lt;h4 id="hda-050" aria-label="Adrain" aria-level="11"&gt;</code> which is reported as <code>h5</code> </li>
+                      <li><code>&lt;h4 id="hda-060" aria-label="Leonie" aria-level="12"&gt;</code> which is reported as <code>h6</code></li>
+                    </ul>
+                    <p>Note that JAWS announces the <code>aria-label</code> text in place of the visible heading text.</p>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/h7-h10.html#hd-006">
+                    Test HD-006: <code>role="heading"</code> + (<code>aria-level</code> 7-12) on <code>div</code> elements</a>:
+                  <p>
+                      <strong>Not supported:</strong> all <code>aria-level</code> examples reported as <code>h2</code>. 
+                    </p>
+                </li>
+              </ul>
+
+            </td>
+            <td>
+              <ul>
+                <li>List Headings <kbd>INSERT</kbd>+<kbd>F6</kbd></li>
+                <li>Next Heading <kbd>H</kbd></li>
+                <li>Prior Heading <kbd>SHIFT+H</kbd></li>
+                <li>First Heading <kbd>ALT+INSERT+HOME</kbd></li>
+                <li>Last Heading <kbd>ALT+INSERT+END </kbd></li>
+                <li>Next Heading at Level - number keys <kbd>1</kbd> through <kbd>6</kbd></li>
+                <li>Prior Heading at Level <kbd>SHIFT+1</kbd> through <kbd>6 </kbd></li>
+                <li>First Heading at Level <kbd>ALT+CTRL+INSERT+1</kbd> through <kbd>6</kbd></li>
+                <li>Last Heading at Level <kbd>ALT+CTRL+INSERT+ SHIFT+1</kbd> through <kbd>6</kbd></li>
               </ul>
             </td>
             <td><svg viewBox="0 0 512 512"
@@ -743,10 +978,7 @@
               </svg>
               <br>
             </td>
-            <td>Issue filed: <a href="https://github.com/FreedomScientific/standards-support/issues/814">JAWS
-
-
-                does not support aria-level on h1-h6</a></td>
+            <td>Issue filed: <a href="https://github.com/FreedomScientific/standards-support/issues/814">JAWS does not support aria-level on h1-h6</a></td>
           </tr>
           <tr>
             <th scope="row"> <a href="https://html.spec.whatwg.org/multipage/sections.html#the-article-element"><code>article</code></a>
@@ -754,7 +986,84 @@
             <td><a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/article.html"><code>article</code>
                 test</a></td>
             <td>Self-contained syndicatable or reusable composition</td>
-            <td>"article" <em>element content</em> "article end"</td>
+            <td>
+              <ul>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/article.html#ar-001">
+                    Test AR-001: Plain <code>article</code></a>: 
+                    <p>Article, <em>article contents</em>, article end</p>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/article.html#ar-002">
+                    Test AR-002: <code>article</code> with <code>&lt;h1&gt;</code></a>: 
+                    <p>Article, <em>article contents</em>, article end</p>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/article.html#ar-003">
+                    Test AR-003: <code>article</code> with <code>aria-label</code></a>: 
+                    <p>
+                      <em>Contents of the <code>aria-label</code> attribute on the <code>&lt;article&gt;</code> element</em>,
+                      article, <em>article contents</em>, 
+                      <em>contents of the <code>aria-label</code> attribute on the <code>&lt;article&gt;</code> element</em>, 
+                      article end
+                    </p>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/article.html#ar-004">
+                    Test AR-004: <code>article</code> with <code>aria-labelledby</code></a>:
+                    <p>
+                      <em>Content referred to from the <code>aria-labelledby</code> attribute
+                        on the <code>&lt;article&gt;</code> element</em>, 
+                        article, <em>article contents</em>, 
+                      <em>Content referred to from the <code>aria-labelledby</code> attribute
+                        on the <code>&lt;article&gt;</code> element</em>, article end
+                    </p>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/article.html#ar-005">
+                    Test AR-005: <code>article</code> with <code>title</code> attribute</a>:
+                    <p>
+                      <em>Contents of the <code>title</code> attribute on the <code>&lt;article&gt;</code> element</em>,
+                      article, <em>article contents</em>, 
+                      <em>contents of the <code>title</code> attribute on the <code>&lt;article&gt;</code> element</em>, 
+                      article end
+                    </p>
+                    <p><strong>Note:</strong> the contents of the <code>title</code> attribute are 
+                    announced after the first word in the body of the article contents is announced, 
+                    rather than alongside the <code>article</code> role when navigating into the article.</p>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/article.html#ar-006">
+                    Test AR-006: <code>article</code> with <code>aria-describedby</code></a>:
+                    <p>
+                      Article, <em>article contents</em>, article end
+                    </p>
+                    <p><strong>Note:</strong> the referenced contents of the <code>aria-describedby</code> attribute
+                    are not announced when navigating into the article.</p>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/article.html#ar-007">
+                    Test AR-007: <code>article</code> with <code>aria-label</code> and <code>title</code> attributes</a>:
+                    <p>
+                      <em>Contents of the <code>aria-label</code> attribute on the <code>&lt;article&gt;</code> element</em>,
+                      article, <em>article contents</em>, 
+                      <em>contents of the <code>aria-label</code> attribute on the <code>&lt;article&gt;</code> element</em>, 
+                      article end
+                    </p>
+                    <p><strong>Note:</strong> the contents of the <code>title</code> attribute are 
+                    announced after the first word in the body of the article contents is announced, 
+                    rather than alongside the <code>article</code> role when navigating into the article.</p>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/article.html#ar-008">
+                    Test AR-008: <code>article</code> with <code>tabindex="0"</code></a>:
+                    <ul>
+                      <li><kbd>Tab</kbd> key navigation: <em>article contents</em>, article region</li>
+                      <li><kbd>Arrow</kbd> key navigation: Article, <em>article contents</em>, article end</li>
+                    </ul>
+                </li>
+              </ul>
+            </td>
             <td>
               <ul>
                 <li>Move to Next Article <kbd>O</kbd> <br>
@@ -774,7 +1083,14 @@
               </svg>
               <br>
             </td>
-            <td>Included as a navigable region &lt; JAWS 2018</td>
+            <td>
+              Included as a navigable region &lt; JAWS 2018
+              <p>&nbsp;</p>
+              <p><strong>Possible bug:</strong> when the <code>title</code> attribute is
+              applied to the <code>&lt;article&gt;</code> element, JAWS does not announce the
+              contents of this attribute when navigating into the article. Instead, it announces the
+              contents of this attribute immediately after announcing the first item inside the article.</p>
+            </td>
           </tr>
           <tr id="jaws-el-aside"
               tabindex="-1">
@@ -803,7 +1119,9 @@
               </svg>
               <br>
             </td>
-            <td>Included as a navigable region</td>
+            <td>
+              Included as a navigable region
+            </td>
           </tr>
           <tr>
             <th scope="row"> <a href="https://html.spec.whatwg.org/multipage/media.html#the-audio-element"><code>audio</code></a> </th>

--- a/JAWS.html
+++ b/JAWS.html
@@ -408,7 +408,7 @@
         <h3>JAWS HTML support table</h3>
         <table>
           <caption>
-            JAWS (2024) HTML Support Chrome Version 135.0.7049.85 (Official Build) (64-bit) on Windows 11
+            JAWS (2026) HTML Support Chrome Version 148.0.7778.97 (Official Build) (64-bit) on Windows 11
           </caption>
 
           <tr>

--- a/JAWS.html
+++ b/JAWS.html
@@ -990,76 +990,144 @@
               <ul>
                 <li>
                   <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/article.html#ar-001">
-                    Test AR-001: Plain <code>article</code></a>: 
-                    <p>Article, <em>article contents</em>, article end</p>
+                    Test AR-001: Plain <code>article</code></a>:
+                    <ul>
+                      <li>
+                        <kbd>O</kbd> / <kbd>Shift</kbd> + <kbd>O</kbd> key navigation (navigating to article container only):
+                        <p>Article</p>
+                      </li>
+                      <li>
+                        <kbd>Arrow</kbd> key navigation (navigating to article container and its contents):
+                        <p>Article, <em>article contents</em>, article end</p>
+                      </li>
+                    </ul>
                 </li>
                 <li>
                   <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/article.html#ar-002">
-                    Test AR-002: <code>article</code> with <code>&lt;h1&gt;</code></a>: 
-                    <p>Article, <em>article contents</em>, article end</p>
+                    Test AR-002: <code>article</code> with <code>&lt;h1&gt;</code></a>:
+                    <ul>
+                      <li>
+                        <kbd>O</kbd> / <kbd>Shift</kbd> + <kbd>O</kbd> key navigation (navigating to article container only):
+                        <p>Article</p>
+                      </li>
+                      <li>
+                        <kbd>Arrow</kbd> key navigation (navigating to article container and its contents):
+                        <p>Article, <em>article contents</em>, article end</p>
+                      </li>
+                    </ul>
                 </li>
                 <li>
                   <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/article.html#ar-003">
-                    Test AR-003: <code>article</code> with <code>aria-label</code></a>: 
-                    <p>
-                      <em>Contents of the <code>aria-label</code> attribute on the <code>&lt;article&gt;</code> element</em>,
-                      article, <em>article contents</em>, 
-                      <em>contents of the <code>aria-label</code> attribute on the <code>&lt;article&gt;</code> element</em>, 
-                      article end
-                    </p>
+                    Test AR-003: <code>article</code> with <code>aria-label</code></a>:
+                  <ul>
+                    <li>
+                      <kbd>O</kbd> / <kbd>Shift</kbd> + <kbd>O</kbd> key navigation (navigating to article container only):
+                      <p><em>Contents of the <code>aria-label</code> attribute</em>, article</p>
+                    </li>
+                    <li>
+                      <kbd>Arrow</kbd> key navigation (navigating to article container and its contents):
+                      <p><em>Contents of the <code>aria-label</code> attribute</em>, article,
+                      <em>article contents</em>, <em>contents of the <code>aria-label</code> attribute</em>, article end</p>
+                    </li>
+                  </ul>
                 </li>
                 <li>
                   <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/article.html#ar-004">
                     Test AR-004: <code>article</code> with <code>aria-labelledby</code></a>:
-                    <p>
-                      <em>Content referred to from the <code>aria-labelledby</code> attribute
-                        on the <code>&lt;article&gt;</code> element</em>, 
-                        article, <em>article contents</em>, 
-                      <em>Content referred to from the <code>aria-labelledby</code> attribute
-                        on the <code>&lt;article&gt;</code> element</em>, article end
-                    </p>
+                  <ul>
+                    <li>
+                      <kbd>O</kbd> / <kbd>Shift</kbd> + <kbd>O</kbd> key navigation (navigating to article container only):
+                      <p><em>Contents referenced by the <code>aria-labelledby</code> attribute</em>, article</p>
+                    </li>
+                    <li>
+                      <kbd>Arrow</kbd> key navigation (navigating to article container and its contents):
+                      <p><em>Contents referenced by the <code>aria-labelledby</code> attribute</em>, article,
+                      <em>article contents</em>, <em>contents referenced by the <code>aria-labelledby</code> attribute</em>, article end</p>
+                    </li>
+                  </ul>
                 </li>
                 <li>
                   <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/article.html#ar-005">
                     Test AR-005: <code>article</code> with <code>title</code> attribute</a>:
-                    <p>
-                      <em>Contents of the <code>title</code> attribute on the <code>&lt;article&gt;</code> element</em>,
-                      article, <em>article contents</em>, 
-                      <em>contents of the <code>title</code> attribute on the <code>&lt;article&gt;</code> element</em>, 
-                      article end
-                    </p>
-                    <p><strong>Note:</strong> the contents of the <code>title</code> attribute are 
-                    announced after the first word in the body of the article contents is announced, 
-                    rather than alongside the <code>article</code> role when navigating into the article.</p>
+                  <ul>
+                    <li>
+                      <kbd>O</kbd> / <kbd>Shift</kbd> + <kbd>O</kbd> key navigation (navigating to article container only):
+                      <p><em>Contents of the <code>title</code> attribute</em>, article</p>
+                    </li>
+                    <li>
+                      <kbd>Arrow</kbd> key navigation (navigating to article container and its contents):
+                      <p>
+                       <em>Contents of the <code>title</code> attribute</em>, <em>article contents</em>, 
+                        <em>contents of the <code>title</code> attribute element</em>, 
+                        article end
+                      </p>
+                      <p><strong>Note:</strong> the contents of the <code>title</code> attribute are 
+                      announced after the first word in the body of the article contents is announced, 
+                      rather than alongside the <code>article</code> role when navigating into the article.</p>
+                    </li>
+                  </ul>
                 </li>
                 <li>
                   <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/article.html#ar-006">
                     Test AR-006: <code>article</code> with <code>aria-describedby</code></a>:
-                    <p>
-                      Article, <em>article contents</em>, article end
-                    </p>
-                    <p><strong>Note:</strong> the referenced contents of the <code>aria-describedby</code> attribute
-                    are not announced when navigating into the article.</p>
+                  <ul>
+                    <li>
+                      <kbd>O</kbd> / <kbd>Shift</kbd> + <kbd>O</kbd> key navigation (navigating to article container only):
+                      <p>Article</p>
+                    </li>
+                    <li>
+                      <kbd>Arrow</kbd> key navigation (navigating to article container and its contents):
+                      <p>
+                        Article, <em>article contents</em>, article end
+                      </p>
+                      <p><strong>Note:</strong> the referenced contents of the <code>aria-describedby</code> attribute
+                      are not announced when navigating to the article container, either when using the 
+                      arrow keys or the <kbd>O</kbd> / <kbd>Shift</kbd> + <kbd>O</kbd> keys.</p>
+                    </li>
+                  </ul>
                 </li>
                 <li>
                   <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/article.html#ar-007">
                     Test AR-007: <code>article</code> with <code>aria-label</code> and <code>title</code> attributes</a>:
-                    <p>
-                      <em>Contents of the <code>aria-label</code> attribute on the <code>&lt;article&gt;</code> element</em>,
-                      article, <em>article contents</em>, 
-                      <em>contents of the <code>aria-label</code> attribute on the <code>&lt;article&gt;</code> element</em>, 
-                      article end
-                    </p>
-                    <p><strong>Note:</strong> the contents of the <code>title</code> attribute are 
-                    announced after the first word in the body of the article contents is announced, 
-                    rather than alongside the <code>article</code> role when navigating into the article.</p>
+                  <ul>
+                    <li>
+                      <kbd>O</kbd> / <kbd>Shift</kbd> + <kbd>O</kbd> key navigation (navigating to article container only):
+                      <p><em>Contents of the <code>aria-label</code> attribute</em>, article</p>
+                    </li>
+                    <li>
+                      <kbd>Arrow</kbd> key navigation (navigating to article container and its contents):
+                      <p>
+                       <em>Contents of the <code>aria-label</code> attribute on the <code>&lt;article&gt;</code> element</em>,
+                       article, <em>article contents</em>, 
+                        <em>contents of the <code>aria-label</code> attribute on the <code>&lt;article&gt;</code> element</em>, 
+                       article end
+                      </p>
+                      <p><strong>Note:</strong> the contents of the <code>title</code> attribute are 
+                      announced after the first word in the body of the article contents is announced, 
+                      rather than alongside the <code>article</code> role when the article container receives focus.</p>
+                    </li>
+                  </ul>
                 </li>
                 <li>
                   <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/article.html#ar-008">
                     Test AR-008: <code>article</code> with <code>tabindex="0"</code></a>:
                     <ul>
-                      <li><kbd>Tab</kbd> key navigation: <em>article contents</em>, article region</li>
-                      <li><kbd>Arrow</kbd> key navigation: Article, <em>article contents</em>, article end</li>
+                      <li>
+                        <kbd>O</kbd> / <kbd>Shift</kbd> + <kbd>O</kbd> key navigation (navigating to article container only):
+                        <p>Article</p>
+                      </li>
+                      <li>
+                        <kbd>Tab</kbd> key navigation (navigating to article container only): 
+                        <p>
+                          <em>article contents</em>, article region
+                        </p>
+                      </li>
+                      <li>
+                        <kbd>Arrow</kbd> key navigation (navigating to article container and its contents): 
+                        <p>
+                          Article, <em>article contents</em>, article end
+                        </p>
+                      </li>
                     </ul>
                 </li>
               </ul>
@@ -1089,7 +1157,8 @@
               <p><strong>Possible bug:</strong> when the <code>title</code> attribute is
               applied to the <code>&lt;article&gt;</code> element, JAWS does not announce the
               contents of this attribute when navigating into the article. Instead, it announces the
-              contents of this attribute immediately after announcing the first item inside the article.</p>
+              contents of this attribute immediately after announcing the first word inside the article.
+              (<a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/article.html#ar-007">Test AR-007</a>)</p>
             </td>
           </tr>
           <tr id="jaws-el-aside"
@@ -1099,7 +1168,149 @@
             <td><a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/aside.html"><code>aside</code>
                 test</a></td>
             <td>Sidebar for tangentially related content</td>
-            <td>"Complimentary information" <em>element content</em> "complimentary information end" </td>
+            <td>
+              <ul>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/aside.html#as-001">
+                    Test AS-001: Plain <code>aside</code></a>: 
+                    <ul>
+                      <li><kbd>R</kbd> / <kbd>Shift</kbd> + <kbd>R</kbd> key navigation (navigating to aside container only):
+                      <p><em>first line of visible text</em>, complementary information</p></li>
+                      <li><kbd>Arrow</kbd> key navigation (navigating to aside container and its contents):
+                      <p><em>visible text</em></p></li>
+                    </ul>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/aside.html#as-002">
+                    Test AS-002: <code>aside</code> with child <code>&lt;h1&gt;</code></a>: 
+                    <ul>
+                      <li><kbd>R</kbd> / <kbd>Shift</kbd> + <kbd>R</kbd> key navigation (navigating to aside container only):
+                        <p><em>first line of visible text</em>, complementary information</p>
+                      </li>
+                      <li><kbd>Arrow</kbd> key navigation (navigating to aside container and its contents):
+                        <p><em>visible text</em></p>
+                      </li>
+                    </ul>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/aside.html#as-003">
+                    Test AS-003: <code>aside</code> with <code>aria-label</code> attribute</a>: 
+                    <ul>
+                      <li><kbd>R</kbd> / <kbd>Shift</kbd> + <kbd>R</kbd> key navigation (navigating to aside container only):
+                      <p><em>first line of visible text</em>, <em>contents of the <code>aria-label</code> attribute</em>, complementary information</p>
+                      </li>
+                      <li>
+                        <kbd>Arrow</kbd> key navigation (navigating to aside container and its contents):
+                        <p><em>visible text</em></p>
+                      </li>
+                    </ul>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/aside.html#as-004">
+                    Test AS-004: <code>aside</code> with <code>aria-labelledby</code></a>: 
+                    <ul>
+                      <li>
+                        <kbd>R</kbd> / <kbd>Shift</kbd> + <kbd>R</kbd> key navigation (navigating to aside container only):
+                        <p><em>first line of visible text, including structural information</em>, <em>content referenced by the <code>aria-labelledby</code> attribute</em>, 
+                        complementary information</p>   
+                      </li>
+                      <li>
+                        <kbd>Arrow</kbd> key navigation (navigating to aside container and its contents):
+                        <p><em>visible text</em></p>
+                      </li>
+                    </ul>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/aside.html#as-005">
+                    Test AS-005: <code>aside</code> with <code>title</code> attribute</a>: 
+                    <ul>
+                      <li>
+                        <kbd>R</kbd> / <kbd>Shift</kbd> + <kbd>R</kbd> key navigation (navigating to aside container only):
+                        <p><em>First word in the visible text</em>, <em>contents of the <code>title</code> attribute</em>,
+                        <em>contents of the <code>title</code> attribute</em>, complimentary information</p>
+                        <p><strong>Notes:</strong></p>
+                        <ul>
+                          <li>The first word in the main body section of the <code>aside</code> is announced</li>
+                          <li>The contents of the <code>title</code> attribute are announced twice</li>
+                        </ul>
+                      </li>
+                      <li>
+                        <kbd>Arrow</kbd> key navigation (navigating to aside container and its contents):
+                        <p>
+                          <em>First word in the visible text</em>, <em>contents of the <code>title</code> attribute</em>,
+                          <em>remainder of the visible text</em>
+                        </p>
+                        <p><strong>Note:</strong> when navigating into the aside container using the <kbd>Down</kbd> arrow key:</p>
+                        <ul>
+                          <li>The first word in the main body section of the <code>aside</code> is announced</li>
+                          <li>The contents of the <code>title</code> attribute are announced</li>
+                          <li>The remaining contents of the <code>aside</code> are announced</li>
+                        </ul>
+                      </li>
+                    </ul>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/aside.html#as-006">
+                    Test AS-006: <code>aside</code> with <code>aria-describedby</code></a>: 
+                    <ul>
+                      <li>
+                        <kbd>R</kbd> / <kbd>Shift</kbd> + <kbd>R</kbd> key navigation (navigating to aside container only): 
+                        <p><em>Content referenced from the <code>aria-describedby</code> attribute, including structural information</em>, complementary information</p>
+                      </li>
+                      <li>
+                        <kbd>Arrow</kbd> key navigation (navigating to aside container and its contents):
+                        <p><em>visible text</em></p>
+                      </li>
+                    </ul>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/aside.html#as-007">
+                    Test AS-007: <code>aside</code> with <code>aria-label</code> and <code>title</code> attributes</a>: 
+                    <ul>
+                      <li>
+                        <kbd>R</kbd> / <kbd>Shift</kbd> + <kbd>R</kbd> key navigation (navigating to aside container only):
+                        <p><em>First word in the visible text</em>, <em>Contents of the <code>title</code> attribute</em>, <em>Contents of the <code>aria-label</code> attribute</em>, complimentary information</p>
+                        <p><strong>Note:</strong> when navigating into the aside container using the <kbd>R</kbd> key:</p>
+                        <ul>
+                          <li>The first word in the main body section of the <code>aside</code> is announced</li>
+                          <li>The contents of the <code>title</code> attribute are announced</li>
+                          <li>The contents of the <code>aria-label</code> attribute are announced</li>
+                          <li><em>Complimentary information</em> is announced</li>
+                        </ul>
+                      </li>
+                      <li>
+                        <kbd>Arrow</kbd> key navigation (navigating to aside container and its contents):
+                        <p><em>First word in the visible text</em>, <em>Contents of the <code>title</code> attribute</em>, 
+                        <em>remainder of the visible text</em></p>
+                        <p><strong>Note:</strong> when navigating into the aside container using the <kbd>Down</kbd> arrow key:</p>
+                        <ul>
+                          <li>The first word in the main body section of the <code>aside</code> is announced</li>
+                          <li>The contents of the <code>title</code> attribute are announced</li>
+                          <li>The remaining contents of the <code>aside</code> are announced</li>
+                        </ul>
+                      </li>
+                    </ul>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/aside.html#as-008">
+                    Test AS-008: <code>aside</code> with <code>tabindex="0"</code></a>: 
+                    <ul>
+                      <li>
+                        <kbd>R</kbd> / <kbd>Shift</kbd> + <kbd>R</kbd> key navigation (navigating to aside container only):
+                        <p><em>visible text</em>, complimentary information</p>
+                      </li>
+                      <li>
+                        <kbd>Arrow</kbd> key navigation (navigating to aside container and its contents):
+                        <p><em>visible text</em></p>
+                      </li>
+                      <li>
+                        <kbd>Tab</kbd> key navigation (navigating to aside container only):
+                        <p><em>visible text</em></p>
+                      </li>
+                    </ul>
+                </li>
+              </ul>
+            </td>
             <td>
               <ul>
                 <li>Move to Next Region&nbsp; <kbd>R</kbd> <br>
@@ -1121,6 +1332,37 @@
             </td>
             <td>
               Included as a navigable region
+              <p>&nbsp;</p>
+              <p><strong>Possible bugs:</strong></p>
+                
+              <p>An issue occurs when the
+              <code>title</code> attribute is applied to the container
+              <code>&lt;aside&gt;</code> element:</p>
+              <ul>
+                <li>
+                  In all cases, an whether the user navigates to the <code>&lt;aside&gt;</code> container
+                  using the <kbd>R</kbd> / <kbd>Shift</kbd> + <kbd>R</kbd> keys or the <kbd>Arrow</kbd>
+                  navigation keys, JAWS announces the first word inside the <code>&lt;aside&gt;</code> container
+                  before anything else 
+                  (<a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/aside.html#as-005">Test AS-005</a>,
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/aside.html#as-007">Test AS-007</a>)
+                </li>
+                <li>
+                  If a user navigates to an <code>&lt;aside&gt;</code> container that only includes a
+                  <code>title</code> attribute using the <kbd>R</kbd> / <kbd>Shift</kbd> + <kbd>R</kbd> keys,
+                  JAWS announces the contents of the <code>title</code> attribute twice
+                  (<a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/aside.html#as-005">Test AS-005</a>)
+                </li>
+              </ul>
+              <p>&nbsp;</p>
+              <p>An issue also occurs when the <code>aria-describedby</code>
+              attribute is applied to the container <code>&lt;aside&gt;</code> element: if 
+              a user navigates to an <code>&lt;aside&gt;</code> container that only includes an
+              <code>aria-describedby</code> attribute using the <kbd>R</kbd> / <kbd>Shift</kbd> + <kbd>R</kbd> keys,
+              JAWS announces structural information about the referenced text (for example, "Heading"
+              to announce that the referenced text is a heading). 
+              (<a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/aside.html#as-006">Test AS-006</a>)</p>
+            
             </td>
           </tr>
           <tr>
@@ -1128,8 +1370,59 @@
             <td><a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/audio.html"><code>audio</code>
                 test</a></td>
             <td>Audio player</td>
-            <td>"audio" "group+<em>accessible name</em>" announces
-              controls as navigated.</td>
+            <td>
+              <p><strong>Note:</strong> the below findings relate to the <code>&lt;audio&gt;</code>, not
+              the controls inside the player</p>
+              <ul>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/audio.html#au-001">Test AU-001: <code>audio</code> element</a>:
+                  <ul>
+                    <li>
+                      <kbd>Arrow</kbd> key navigation:
+                      <p>Audio start, <em>audio player controls</em>, audio end</p>
+                    </li>
+                    <li>
+                      <kbd>Tab</kbd> key navigation:
+                      <p>Elapsed time, colon zero colon zero zero one zero zero, mute, group</p>
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/audio.html#au-002">Test AU-002: <code>audio</code> element with <code>aria-label</code></a>:
+                  <ul>
+                    <li>
+                      <kbd>Arrow</kbd> key navigation:
+                      <p>Audio start, group start, <em>contents of the <code>aria-label</code> attribute</em>, <em>audio player controls</em>, group end, <em>contents of the <code>aria-label</code> attribute</em>, audio end</p>
+                    </li>
+                    <li>
+                      <kbd>Tab</kbd> key navigation:
+                      <p>One of the following (refer to notes):</p>
+                      <ol>
+                        <li>Elapsed time, colon zero colon zero zero one zero zero, mute, group; <strong>or</strong></strong></li>
+                        <li><em>contents of the <code>aria-label</code> attribute</em>, group</li>
+                      </ol>
+                    </li>
+                  </ul>
+                </li>
+                <li>
+                  <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/audio.html#au-003">Test AU-003: <code>audio</code> element with <code>aria-label</code> and <code>aria-describedby</code></a>:
+                  <ul>
+                    <li>
+                      <kbd>Arrow</kbd> key navigation:
+                      <p>Audio start, group start, <em>contents of the <code>aria-label</code> attribute</em>, <em>audio player controls</em>, group end, <em>contents of the <code>aria-label</code> attribute</em>, audio end</p>
+                    </li>
+                    <li>
+                      <kbd>Tab</kbd> key navigation:
+                      <p>One of the following (refer to notes):</p>
+                      <ol>
+                        <li>Elapsed time, colon zero colon zero zero one zero zero, mute, group; <strong>or</strong></strong></li>
+                        <li><em>contents of the <code>aria-label</code> attribute</em>, group</li>
+                      </ol>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </td>
             <td> If the audio element has a <code>controls</code> attribute the buttons in the UI are navigable using <a href="#button-commands">button</a> commands. </td>
             <td><svg viewBox="0 0 448 512"
                    width="20"
@@ -1140,7 +1433,22 @@
               </svg>
               <br>
             </td>
-            <td>Controls in the audio player are accessible.</td>
+            <td>
+              Controls in the audio player are accessible.
+              <p>&nbsp;</p>
+              <p><strong>Possible bugs:</strong></p>
+              <ul>
+                <li>JAWS does not announced the content referenced by the <code>aria-describedby</code> 
+                  attribute when the container <code>&lt;audio&gt;</code> element receives focus 
+                  (either using reading keys or the <kbd>Tab</kbd> key)
+                  (<a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/audio.html#au-003">Test AU-003</a>)
+                </li>
+                <li>JAWS does not announce the role and accessible name of the player consistently when the <code>&lt;audio&gt;</code> container receives <kbd>Tab</kbd> focus; it sometimes announces the role and state, but other times it announces
+                random content within the player. To resolve this, a user can navigate to the Play button and then press the <kbd>Shift</kbd> + <kbd>Tab</kbd> keys to navigate back to the container, at which point
+                the correct role and name information is conveyed. (<a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/audio.html#au-001">Test AU-001</a>, <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/audio.html#au-002">Test AU-002</a>, <a href="https://stevefaulkner.github.io/AT-browser-tests/test-files/audio.html#au-003">Test AU-003</a>)
+                </li>
+              </ul>
+            </td>
           </tr>
           <tr id="toc-b">
             <th scope="row"> <a href="https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-b-element"><code>b</code></a>

--- a/JAWS.html
+++ b/JAWS.html
@@ -225,7 +225,7 @@
   </header>
   <div class="region wrapper prose flow">
 
-    <h1>JAWS HTML Support test</h1>
+    <h1>JAWS HTML Support</h1>
     <dl>
       <dt>A Work <em>in progress</em>:</dt>
       <dd>Last updated 3 February 2026. </dd>

--- a/JAWS.html
+++ b/JAWS.html
@@ -228,7 +228,7 @@
     <h1>JAWS HTML Support</h1>
     <dl>
       <dt>A Work <em>in progress</em>:</dt>
-      <dd>Last updated 7 May 2026. </dd>
+      <dd>Last updated 11 May 2026. </dd>
       <dt>Editor:</dt>
       <dd>Steve Faulkner</dd>
       <dt>Co-editor:</dt>


### PR DESCRIPTION
Updates the findings for all elements beginning with the letter "a".